### PR TITLE
Optimized the hyperparameters of the models

### DIFF
--- a/opencda/coperception_models/point_pillar_fcooper/config.yaml
+++ b/opencda/coperception_models/point_pillar_fcooper/config.yaml
@@ -135,13 +135,13 @@ postprocess:
     vw: 0.4
     w: 1.6
   core_method: VoxelPostprocessor
-  max_num: 100
-  nms_thresh: 0.15
+  max_num: 12
+  nms_thresh: 0.001
   order: hwl
   target_args:
-    neg_threshold: 0.45
-    pos_threshold: 0.6
-    score_threshold: 0.2
+    neg_threshold: 0.3
+    pos_threshold: 0.7
+    score_threshold: 0.4
 preprocess:
   args:
     max_points_per_voxel: 32

--- a/opencda/coperception_models/point_pillar_intermediate_fusion/config.yaml
+++ b/opencda/coperception_models/point_pillar_intermediate_fusion/config.yaml
@@ -123,13 +123,13 @@ postprocess:
     vw: 0.4
     w: 1.6
   core_method: VoxelPostprocessor
-  max_num: 100
-  nms_thresh: 0.15
+  max_num: 12
+  nms_thresh: 0.001
   order: hwl
   target_args:
-    neg_threshold: 0.45
-    pos_threshold: 0.6
-    score_threshold: 0.20
+    neg_threshold: 0.3
+    pos_threshold: 0.7
+    score_threshold: 0.5
 preprocess:
   args:
     max_points_per_voxel: 32

--- a/opencda/coperception_models/second_intermediate_fusion/config.yaml
+++ b/opencda/coperception_models/second_intermediate_fusion/config.yaml
@@ -117,13 +117,13 @@ postprocess:
     vw: 0.1
     w: 1.6
   core_method: VoxelPostprocessor
-  max_num: 100
-  nms_thresh: 0.15
+  max_num: 12
+  nms_thresh: 0.001
   order: hwl
   target_args:
-    neg_threshold: 0.45
-    pos_threshold: 0.6
-    score_threshold: 0.2
+    neg_threshold: 0.3
+    pos_threshold: 0.7
+    score_threshold: 0.5
 preprocess:
   args:
     max_points_per_voxel: 5

--- a/opencda/coperception_models/voxelnet_early_fusion/config.yaml
+++ b/opencda/coperception_models/voxelnet_early_fusion/config.yaml
@@ -76,12 +76,107 @@ postprocess:
     w: 1.6
   core_method: VoxelPostprocessor
   max_num: 100
-  nms_thresh: 0.15
+  nms_thresh: 0.01
   order: hwl
   target_args:
-    neg_threshold: 0.45
-    pos_threshold: 0.6
-    score_threshold: 0.20
+    neg_threshold: 0.3
+    pos_threshold: 0.7
+    score_threshold: 0.3
+preprocess:
+  args:
+    max_points_per_voxel: 32
+    max_voxel_test: 70000
+    max_voxel_train: 36000
+    voxel_size: *id002
+  cav_lidar_range: *id001
+  core_method: SpVoxelPreprocessor
+root_dir: "opv2v_data_dumping/train"
+validate_dir: "simulation_output/data_dumping/sample"
+yaml_parser: load_voxel_params
+data_augment:
+- ALONG_AXIS_LIST:
+  - x
+  NAME: random_world_flip
+- NAME: random_world_rotation
+  WORLD_ROT_ANGLE:
+  - -0.78539816
+  - 0.78539816
+- NAME: random_world_scaling
+  WORLD_SCALE_RANGE:
+  - 0.95
+  - 1.05
+fusion:
+  args: []
+  core_method: EarlyFusionDataset
+loss:
+  args:
+    cls_weight: 1.0
+    reg: 2.0
+  core_method: point_pillar_loss
+lr_scheduler:
+  core_method: multistep
+  gamma: 0.1
+  step_size:
+  - 15
+  - 30
+model:
+  args:
+    D: 10
+    H: 200
+    N: 1
+    T: 32
+    W: 704
+    anchor_num: 2
+    lidar_range: &id001
+    - -140.8
+    - -40
+    - -3
+    - 140.8
+    - 40
+    - 1
+    pillar_vfe:
+      num_filters:
+      - 64
+      use_absolute_xyz: true
+      use_norm: true
+      with_distance: false
+    voxel_size: &id002
+    - 0.4
+    - 0.4
+    - 0.4
+  core_method: voxel_net
+name: voxelnet_early_fusion
+optimizer:
+  args:
+    eps: 1.0e-10
+    weight_decay: 0.0001
+  core_method: Adam
+  lr: 0.002
+postprocess:
+  gt_range: *id001
+  anchor_args:
+    D: 10
+    H: 200
+    W: 704
+    cav_lidar_range: *id001
+    h: 1.56
+    l: 3.9
+    num: 2
+    r:
+    - 0
+    - 90
+    vd: 0.4
+    vh: 0.4
+    vw: 0.4
+    w: 1.6
+  core_method: VoxelPostprocessor
+  max_num: 100
+  nms_thresh: 0.01
+  order: hwl
+  target_args:
+    neg_threshold: 0.3
+    pos_threshold: 0.7
+    score_threshold: 0.3
 preprocess:
   args:
     max_points_per_voxel: 32

--- a/opencda/coperception_models/voxelnet_intermediate_fusion/config.yaml
+++ b/opencda/coperception_models/voxelnet_intermediate_fusion/config.yaml
@@ -76,13 +76,13 @@ postprocess:
     vw: 0.4
     w: 1.6
   core_method: VoxelPostprocessor
-  max_num: 100
-  nms_thresh: 0.15
+  max_num: 12
+  nms_thresh: 0.001
   order: hwl
   target_args:
-    neg_threshold: 0.45
-    pos_threshold: 0.6
-    score_threshold: 0.25
+    neg_threshold: 0.3
+    pos_threshold: 0.7
+    score_threshold: 0.46
 preprocess:
   args:
     max_points_per_voxel: 32


### PR DESCRIPTION
Description
Optimized max_num, nms_thresh, neg_threshold, pos_threshold, score_threshold parameters in config.yaml for second_intermediate_fusion, point_pillar_fcopper, point_pillar_intermediate_fusion models.

Checklist

- [x]  found more optimal parametres

 

- [x] experimentally checked them

example of optimized point_pillar_intermediate_fusion
<img width="327" height="313" alt="image" src="https://github.com/user-attachments/assets/ac3eec53-a918-4b2d-91fa-c9bc80e9aa8d" />
<img width="908" height="378" alt="image" src="https://github.com/user-attachments/assets/62724ef2-0b86-4a57-ba3f-73a1a7e6cb27" />

