### PR TITLE
[CI] Add mypy

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,4 +1,4 @@
-name: Lint and Format Check
+name: Lint, Format and Type Check
 
 on: [ pull_request ]
 
@@ -22,3 +22,18 @@ jobs:
         uses: astral-sh/ruff-action@v3
         with:
           args: "format --check --diff"
+
+  type-chek:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install Dependencies
+        run: pip install mypy
+      - name: Run mypy
+        run: mypy .
+        continue-on-error: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,3 +76,18 @@ docstring-code-format = true
 # This only has an effect when the `docstring-code-format` setting is
 # enabled.
 docstring-code-line-length = "dynamic"
+
+
+[tool.mypy]
+python_version = "3.10"
+ignore_missing_imports = true
+disallow_untyped_defs = true
+check_untyped_defs = true
+warn_unused_ignores = true
+pretty = true
+
+exclude_gitignore = true
+exclude = [
+    'docs',
+    'test'
+]

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ carla==0.9.16
 
 # Packaging, Build & Runtime Utilities
 coloredlogs==15.0.1
+cumm==0.8.2
 
 # Optimization & Convex Programming
 cvxpy==1.7.3
@@ -15,6 +16,9 @@ lxml==6.0.2
 
 # Visualization & Logging
 matplotlib==3.10.7
+
+# Tools
+mypy==1.19.1
 
 # Graphs & Networks
 networkx==3.5
@@ -52,14 +56,12 @@ scipy==1.16.3
 seaborn==0.13.2
 shapely==2.1.2
 six==1.17.0
-cumm==0.8.2
 sumolib==1.24.0
 tensorboardX==2.6.4
 timm==1.0.22
-torch_geometric==2.7.0
 torch --index-url https://download.pytorch.org/whl/cu128
+torch_geometric==2.7.0
 torchvision --index-url https://download.pytorch.org/whl/cu128
 tqdm==4.67.1
 traci==1.24.0
 typing-extensions==4.15.0
-cumm==0.8.2


### PR DESCRIPTION
This PR adds mypy type checking and a corresponding CI job.

The mypy job is currently marked as "continue-on-error" to avoid blocking the pipeline. Once all existing type warnings are resolved, the job will be switched to a required check.

Mypy runs with following parameters:
- ignore_missing_imports
- disallow_untyped_defs
- check_untyped_defs
- warn_unused_ignores
- pretty