### PR TITLE
[CI] Add deadcode check

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,4 +1,4 @@
-name: Lint, Format, Type and Deadcode Check
+name: Lint, Format, Type and Unused code Check
 
 on: [ pull_request ]
 


### PR DESCRIPTION
This PR adds deadcode checking and a corresponding CI job.

The deadcode job is currently marked as "continue-on-error" to avoid blocking the pipeline. Once all existing type warnings are resolved, the job will be switched to a required check.