### PR TITLE
[pre-commit] Add excluded directories for check-merge-conflict hook

### DIFF
--- a/.github/pre-commit-config-ci.yaml
+++ b/.github/pre-commit-config-ci.yaml
@@ -9,6 +9,7 @@ repos:
     - id: check-json
     - id: check-merge-conflict
       args: ["--assume-in-merge"]
+      exclude: '(docs/.*|OpenCOOD/docs/.*)'
     - id: check-shebang-scripts-are-executable
     - id: check-symlinks
     - id: check-toml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,6 +16,7 @@ repos:
     - id: check-json
     - id: check-merge-conflict
       args: ["--assume-in-merge"]
+      exclude: '(docs/.*|OpenCOOD/docs/.*)'
     - id: check-shebang-scripts-are-executable
     - id: check-symlinks
     - id: check-toml


### PR DESCRIPTION
Fix bug when check-merge-conflict finds `=====` in docs files.