### PR TITLE
[Docker, Upgrade] Upgrade packages in the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ RUN apt-get update && \
         python3-dev=3.12.3-0ubuntu2.1 \
 
         vulkan-tools=1.3.275.0+dfsg1-1 \
-        libglib2.0-0 \
+        libglib2.0-0=2.80.0-6ubuntu3.7  \
     && \
 
     curl -LO https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/${PROTOC_ZIP} && \


### PR DESCRIPTION
Update mesa-vulkan-drivers to version 25.2.8-0ubuntu0.24.04.1 and update libglib2.0-0 to version  2.80.0-6ubuntu3.7 