### PR TITLE
[bugfix] Fix bug with name function of coperception manager

### DIFF
--- a/opencda/scenario_testing/scenario.py
+++ b/opencda/scenario_testing/scenario.py
@@ -208,7 +208,7 @@ class Scenario:
                 except Exception as e:
                     logger.warning(f"An error occurred during proceesing {tick_number} tick: {e}")
 
-                self.coperception_model_manager.make_dataset()
+                self.coperception_model_manager.update_dataset()
                 self.coperception_model_manager.make_prediction(tick_number)
 
             if self.platoon_list is not None:
@@ -265,7 +265,7 @@ class Scenario:
                 except Exception as e:
                     logger.warning(f"An error occurred during proceesing {tick_number} tick: {e}")
 
-                self.coperception_model_manager.make_dataset()
+                self.coperception_model_manager.update_dataset()
                 self.coperception_model_manager.opencood_dataset.extract_data(
                     idx=0  # TODO: Figure out how to select the ego vehicle in cooperative perception models
                 )


### PR DESCRIPTION
Hotfix: Sync function call with renamed function

Fixes a bug where `make_dataset()` was still being called after the function was renamed to `update_dataset`.