### PR TITLE
[visualize] Improve coperception visualization (any colors) with new CoperceptionVisualizer

### DIFF
--- a/OpenCOOD/opencood/data_utils/datasets/early_fusion_dataset.py
+++ b/OpenCOOD/opencood/data_utils/datasets/early_fusion_dataset.py
@@ -14,7 +14,7 @@ from opencood.utils import box_utils
 from opencood.data_utils.post_processor import build_postprocessor
 from opencood.data_utils.datasets import basedataset
 from opencood.data_utils.pre_processor import build_preprocessor
-from opencood.utils.pcd_utils import mask_points_by_range, mask_ego_points, shuffle_points, downsample_lidar_minimum
+from opencood.utils.pcd_utils import mask_ego_points, shuffle_points, downsample_lidar_minimum
 from opencood.utils.transformation_utils import x1_to_x2
 
 logger = logging.getLogger("cavise.opencda.OpenCOOD.opencood.data_utils.datasets.early_fusion_dataset")
@@ -67,6 +67,8 @@ class EarlyFusionDataset(basedataset.BaseDataset):
         object_stack = []
         object_id_stack = []
         projected_lidar_stack = []
+        projected_lidar_roles = []
+        projected_lidar_agent_ids = []
 
         ego_cav_base = base_data_dict.get(ego_id)
         ego_cav_processed = self.get_item_single_car(ego_cav_base, ego_lidar_pose)
@@ -74,6 +76,8 @@ class EarlyFusionDataset(basedataset.BaseDataset):
         object_id_stack += ego_cav_processed["object_ids"]
         object_stack.append(ego_cav_processed["object_bbx_center"])
         projected_lidar_stack.append(ego_cav_processed["projected_lidar"])
+        projected_lidar_roles.append("ego")
+        projected_lidar_agent_ids.append(ego_id)
 
         if ego_id in self.payload_handler.current_artery_payload:
             for cav_id, _ in base_data_dict.items():
@@ -82,16 +86,26 @@ class EarlyFusionDataset(basedataset.BaseDataset):
                         object_id_stack += msg["object_ids"]
                         object_stack.append(msg["object_bbx_center"])
                         projected_lidar_stack.append(msg["projected_lidar"])
+                        projected_lidar_roles.append("other")
+                        projected_lidar_agent_ids.append(cav_id)
 
-        return {"object_stack": object_stack, "object_id_stack": object_id_stack, "projected_lidar_stack": projected_lidar_stack}
+        return {
+            "object_stack": object_stack,
+            "object_id_stack": object_id_stack,
+            "projected_lidar_stack": projected_lidar_stack,
+            "projected_lidar_roles": projected_lidar_roles,
+            "projected_lidar_agent_ids": projected_lidar_agent_ids,
+        }
 
     def __process_without_messages(self, ego_lidar_pose, base_data_dict):
         projected_lidar_stack = []
         object_stack = []
         object_id_stack = []
+        projected_lidar_roles = []
+        projected_lidar_agent_ids = []
 
         # loop over all CAVs to process information
-        for _, selected_cav_base in base_data_dict.items():
+        for cav_id, selected_cav_base in base_data_dict.items():
             # check if the cav is within the communication range with ego
             dx = selected_cav_base["params"]["lidar_pose"][0] - ego_lidar_pose[0]
             dy = selected_cav_base["params"]["lidar_pose"][1] - ego_lidar_pose[1]
@@ -104,8 +118,16 @@ class EarlyFusionDataset(basedataset.BaseDataset):
             projected_lidar_stack.append(selected_cav_processed["projected_lidar"])
             object_stack.append(selected_cav_processed["object_bbx_center"])
             object_id_stack += selected_cav_processed["object_ids"]
+            projected_lidar_roles.append("ego" if selected_cav_base["ego"] else "other")
+            projected_lidar_agent_ids.append(cav_id)
 
-        return {"object_stack": object_stack, "object_id_stack": object_id_stack, "projected_lidar_stack": projected_lidar_stack}
+        return {
+            "object_stack": object_stack,
+            "object_id_stack": object_id_stack,
+            "projected_lidar_stack": projected_lidar_stack,
+            "projected_lidar_roles": projected_lidar_roles,
+            "projected_lidar_agent_ids": projected_lidar_agent_ids,
+        }
 
     def __getitem__(self, idx):
         base_data_dict = self.retrieve_base_data(idx)
@@ -132,16 +154,29 @@ class EarlyFusionDataset(basedataset.BaseDataset):
 
         # convert list to numpy array, (N, 4)
         projected_lidar_stack = np.vstack(data["projected_lidar_stack"])
+        point_source = np.concatenate(
+            [np.full(points.shape[0], idx, dtype=np.int32) for idx, points in enumerate(data["projected_lidar_stack"])], axis=0
+        )
 
         # data augmentation
         projected_lidar_stack, object_bbx_center, mask = self.augment(projected_lidar_stack, object_bbx_center, mask)
 
         # we do lidar filtering in the stacked lidar
-        projected_lidar_stack = mask_points_by_range(projected_lidar_stack, self.params["preprocess"]["cav_lidar_range"])
+        lidar_range = self.params["preprocess"]["cav_lidar_range"]
+        lidar_mask = (
+            (projected_lidar_stack[:, 0] > lidar_range[0])
+            & (projected_lidar_stack[:, 0] < lidar_range[3])
+            & (projected_lidar_stack[:, 1] > lidar_range[1])
+            & (projected_lidar_stack[:, 1] < lidar_range[4])
+            & (projected_lidar_stack[:, 2] > lidar_range[2])
+            & (projected_lidar_stack[:, 2] < lidar_range[5])
+        )
+        projected_lidar_stack = projected_lidar_stack[lidar_mask]
+        point_source = point_source[lidar_mask]
         # augmentation may remove some of the bbx out of range
         object_bbx_center_valid = object_bbx_center[mask == 1]
         object_bbx_center_valid, range_mask = box_utils.mask_boxes_outside_range_numpy(
-            object_bbx_center_valid, self.params["preprocess"]["cav_lidar_range"], self.params["postprocess"]["order"], return_mask=True
+            object_bbx_center_valid, lidar_range, self.params["postprocess"]["order"], return_mask=True
         )
         mask[object_bbx_center_valid.shape[0] :] = 0
         object_bbx_center[: object_bbx_center_valid.shape[0]] = object_bbx_center_valid
@@ -169,7 +204,15 @@ class EarlyFusionDataset(basedataset.BaseDataset):
         )
 
         if self.visualize:
-            processed_data_dict["ego"].update({"origin_lidar": projected_lidar_stack})
+            valid_agent_indices = [idx for idx in range(len(data["projected_lidar_roles"])) if np.any(point_source == idx)]
+            processed_data_dict["ego"].update(
+                {
+                    "origin_lidar": projected_lidar_stack,
+                    "origin_lidar_by_agent": [projected_lidar_stack[point_source == idx] for idx in valid_agent_indices],
+                    "origin_lidar_roles": [data["projected_lidar_roles"][idx] for idx in valid_agent_indices],
+                    "origin_lidar_agent_ids": [data["projected_lidar_agent_ids"][idx] for idx in valid_agent_indices],
+                }
+            )
 
         return processed_data_dict
 
@@ -268,6 +311,14 @@ class EarlyFusionDataset(basedataset.BaseDataset):
                 origin_lidar = np.array(downsample_lidar_minimum(pcd_np_list=origin_lidar))
                 origin_lidar = torch.from_numpy(origin_lidar)
                 output_dict[cav_id].update({"origin_lidar": origin_lidar})
+                if "origin_lidar_by_agent" in cav_content:
+                    output_dict[cav_id].update(
+                        {
+                            "origin_lidar_by_agent": [torch.from_numpy(np.array(points)) for points in cav_content["origin_lidar_by_agent"]],
+                            "origin_lidar_roles": list(cav_content["origin_lidar_roles"]),
+                            "origin_lidar_agent_ids": list(cav_content["origin_lidar_agent_ids"]),
+                        }
+                    )
 
         return output_dict
 

--- a/OpenCOOD/opencood/data_utils/datasets/intermediate_fusion_dataset.py
+++ b/OpenCOOD/opencood/data_utils/datasets/intermediate_fusion_dataset.py
@@ -122,6 +122,8 @@ class IntermediateFusionDataset(basedataset.BaseDataset):
         infra = []
         spatial_correction_matrix = []
         projected_lidar_stack = [] if self.visualize else None
+        projected_lidar_roles = [] if self.visualize else None
+        projected_lidar_agent_ids = [] if self.visualize else None
 
         ego_cav_base = base_data_dict.get(ego_id)
         ego_cav_processed = self.get_item_single_car(ego_cav_base, ego_lidar_pose)
@@ -135,6 +137,8 @@ class IntermediateFusionDataset(basedataset.BaseDataset):
         processed_features.append(ego_cav_processed["processed_features"])
         if self.visualize:
             projected_lidar_stack.append(ego_cav_processed["projected_lidar"])
+            projected_lidar_roles.append("ego")
+            projected_lidar_agent_ids.append(ego_id)
 
         if ego_id in self.payload_handler.current_artery_payload:
             for cav_id, _ in base_data_dict.items():
@@ -158,6 +162,8 @@ class IntermediateFusionDataset(basedataset.BaseDataset):
 
                         if self.visualize:
                             projected_lidar_stack.append(msg["projected_lidar"])
+                            projected_lidar_roles.append("other")
+                            projected_lidar_agent_ids.append(cav_id)
 
         return {
             "processed_features": processed_features,
@@ -168,6 +174,8 @@ class IntermediateFusionDataset(basedataset.BaseDataset):
             "infra": infra,
             "spatial_correction_matrix": spatial_correction_matrix,
             "projected_lidar_stack": projected_lidar_stack or [],
+            "projected_lidar_roles": projected_lidar_roles or [],
+            "projected_lidar_agent_ids": projected_lidar_agent_ids or [],
         }
 
     def __process_without_messages(self, ego_lidar_pose, base_data_dict):
@@ -179,6 +187,8 @@ class IntermediateFusionDataset(basedataset.BaseDataset):
         infra = []
         spatial_correction_matrix = []
         projected_lidar_stack = [] if self.visualize else None
+        projected_lidar_roles = [] if self.visualize else None
+        projected_lidar_agent_ids = [] if self.visualize else None
 
         for cav_id, selected_cav_base in base_data_dict.items():
             dx = selected_cav_base["params"]["lidar_pose"][0] - ego_lidar_pose[0]
@@ -200,6 +210,8 @@ class IntermediateFusionDataset(basedataset.BaseDataset):
 
             if self.visualize:
                 projected_lidar_stack.append(selected_cav_processed["projected_lidar"])
+                projected_lidar_roles.append("ego" if selected_cav_base["ego"] else "other")
+                projected_lidar_agent_ids.append(cav_id)
 
         return {
             "processed_features": processed_features,
@@ -210,6 +222,8 @@ class IntermediateFusionDataset(basedataset.BaseDataset):
             "infra": infra,
             "spatial_correction_matrix": spatial_correction_matrix,
             "projected_lidar_stack": projected_lidar_stack or [],
+            "projected_lidar_roles": projected_lidar_roles or [],
+            "projected_lidar_agent_ids": projected_lidar_agent_ids or [],
         }
 
     def __getitem__(self, idx):
@@ -254,7 +268,14 @@ class IntermediateFusionDataset(basedataset.BaseDataset):
         )
 
         if self.visualize:
-            processed_data_dict["ego"]["origin_lidar"] = np.vstack(data["projected_lidar_stack"])
+            processed_data_dict["ego"].update(
+                {
+                    "origin_lidar": np.vstack(data["projected_lidar_stack"]),
+                    "origin_lidar_by_agent": data["projected_lidar_stack"],
+                    "origin_lidar_roles": data["projected_lidar_roles"],
+                    "origin_lidar_agent_ids": data["projected_lidar_agent_ids"],
+                }
+            )
 
         return processed_data_dict
 
@@ -438,6 +459,15 @@ class IntermediateFusionDataset(basedataset.BaseDataset):
         # check if anchor box in the batch
         if batch[0]["ego"]["anchor_box"] is not None:
             output_dict["ego"].update({"anchor_box": torch.from_numpy(np.array(batch[0]["ego"]["anchor_box"]))})
+
+        if self.visualize and "origin_lidar_by_agent" in batch[0]["ego"]:
+            output_dict["ego"].update(
+                {
+                    "origin_lidar_by_agent": [torch.from_numpy(np.array(points)) for points in batch[0]["ego"]["origin_lidar_by_agent"]],
+                    "origin_lidar_roles": list(batch[0]["ego"]["origin_lidar_roles"]),
+                    "origin_lidar_agent_ids": list(batch[0]["ego"]["origin_lidar_agent_ids"]),
+                }
+            )
 
         # save the transformation matrix (4, 4) to ego vehicle
         transformation_matrix_torch = torch.from_numpy(np.identity(4)).float()

--- a/OpenCOOD/opencood/data_utils/datasets/intermediate_fusion_dataset_v2.py
+++ b/OpenCOOD/opencood/data_utils/datasets/intermediate_fusion_dataset_v2.py
@@ -77,6 +77,8 @@ class IntermediateFusionDatasetV2(basedataset.BaseDataset):
         object_stack = []
         object_id_stack = []
         projected_lidar_stack = []
+        projected_lidar_roles = []
+        projected_lidar_agent_ids = []
 
         ego_cav_base = base_data_dict.get(ego_id)
         ego_cav_processed = self.get_item_single_car(ego_cav_base, ego_lidar_pose)
@@ -85,6 +87,8 @@ class IntermediateFusionDatasetV2(basedataset.BaseDataset):
         object_stack.append(ego_cav_processed["object_bbx_center"])
         processed_features.append(ego_cav_processed["processed_features"])
         projected_lidar_stack.append(ego_cav_processed["projected_lidar"])
+        projected_lidar_roles.append("ego")
+        projected_lidar_agent_ids.append(ego_id)
 
         if ego_id in self.payload_handler.current_artery_payload:
             for cav_id, _ in base_data_dict.items():
@@ -94,6 +98,8 @@ class IntermediateFusionDatasetV2(basedataset.BaseDataset):
 
                         if len(projected) > 10:
                             projected_lidar_stack.append(projected)
+                            projected_lidar_roles.append("other")
+                            projected_lidar_agent_ids.append(cav_id)
 
                             object_id_stack += msg["object_ids"]
                             object_stack.append(msg["object_bbx_center"])
@@ -111,6 +117,8 @@ class IntermediateFusionDatasetV2(basedataset.BaseDataset):
             "object_stack": object_stack,
             "object_id_stack": object_id_stack,
             "projected_lidar_stack": projected_lidar_stack,
+            "projected_lidar_roles": projected_lidar_roles,
+            "projected_lidar_agent_ids": projected_lidar_agent_ids,
         }
 
     def __process_without_messages(self, ego_lidar_pose, base_data_dict):
@@ -118,6 +126,8 @@ class IntermediateFusionDatasetV2(basedataset.BaseDataset):
         object_stack = []
         object_id_stack = []
         projected_lidar_stack = []
+        projected_lidar_roles = []
+        projected_lidar_agent_ids = []
 
         for cav_id, selected_cav_base in base_data_dict.items():
             dx = selected_cav_base["params"]["lidar_pose"][0] - ego_lidar_pose[0]
@@ -135,12 +145,16 @@ class IntermediateFusionDatasetV2(basedataset.BaseDataset):
                 processed_features.append(selected_cav_processed["processed_features"])
 
                 projected_lidar_stack.append(selected_cav_processed["projected_lidar"])
+                projected_lidar_roles.append("ego" if selected_cav_base["ego"] else "other")
+                projected_lidar_agent_ids.append(cav_id)
 
         return {
             "processed_features": processed_features,
             "object_stack": object_stack,
             "object_id_stack": object_id_stack,
             "projected_lidar_stack": projected_lidar_stack,
+            "projected_lidar_roles": projected_lidar_roles,
+            "projected_lidar_agent_ids": projected_lidar_agent_ids,
         }
 
     def __getitem__(self, idx):
@@ -222,7 +236,14 @@ class IntermediateFusionDatasetV2(basedataset.BaseDataset):
             }
         )
 
-        processed_data_dict["ego"].update({"origin_lidar": data["projected_lidar_stack"]})
+        processed_data_dict["ego"].update(
+            {
+                "origin_lidar": data["projected_lidar_stack"],
+                "origin_lidar_by_agent": data["projected_lidar_stack"],
+                "origin_lidar_roles": data["projected_lidar_roles"],
+                "origin_lidar_agent_ids": data["projected_lidar_agent_ids"],
+            }
+        )
         return processed_data_dict
 
     def get_item_single_car(self, selected_cav_base, ego_pose):
@@ -385,6 +406,15 @@ class IntermediateFusionDatasetV2(basedataset.BaseDataset):
         # check if anchor box in the batch
         if batch[0]["ego"]["anchor_box"] is not None:
             output_dict["ego"].update({"anchor_box": torch.from_numpy(np.array(batch[0]["ego"]["anchor_box"]))})
+
+        if "origin_lidar_by_agent" in batch[0]["ego"]:
+            output_dict["ego"].update(
+                {
+                    "origin_lidar_by_agent": [torch.from_numpy(np.array(points)) for points in batch[0]["ego"]["origin_lidar_by_agent"]],
+                    "origin_lidar_roles": list(batch[0]["ego"]["origin_lidar_roles"]),
+                    "origin_lidar_agent_ids": list(batch[0]["ego"]["origin_lidar_agent_ids"]),
+                }
+            )
 
         # save the transformation matrix (4, 4) to ego vehicle
         transformation_matrix_torch = torch.from_numpy(np.identity(4)).float()

--- a/OpenCOOD/opencood/data_utils/datasets/late_fusion_dataset.py
+++ b/OpenCOOD/opencood/data_utils/datasets/late_fusion_dataset.py
@@ -300,9 +300,10 @@ class LateFusionDataset(basedataset.BaseDataset):
                 output_dict[cav_id].update({"anchor_box": torch.from_numpy(np.array(cav_content["anchor_box"]))})
             if self.visualize:
                 transformation_matrix = cav_content["transformation_matrix"]
-                origin_lidar = [cav_content["origin_lidar"]]
+                local_lidar = np.array(cav_content["origin_lidar"], copy=True)
+                origin_lidar = [local_lidar]
 
-                projected_lidar = cav_content["origin_lidar"]
+                projected_lidar = np.array(cav_content["origin_lidar"], copy=True)
                 projected_lidar[:, :3] = box_utils.project_points_by_matrix_torch(projected_lidar[:, :3], transformation_matrix)
                 projected_lidar_list.append(projected_lidar)
 
@@ -328,7 +329,7 @@ class LateFusionDataset(basedataset.BaseDataset):
             if self.visualize:
                 origin_lidar = np.array(downsample_lidar_minimum(pcd_np_list=origin_lidar))
                 origin_lidar = torch.from_numpy(origin_lidar)
-                output_dict[cav_id].update({"origin_lidar": origin_lidar})
+                output_dict[cav_id].update({"origin_lidar": origin_lidar, "origin_lidar_local": origin_lidar.clone(), "agent_id": cav_id})
 
         if self.visualize:
             projected_lidar_stack = torch.from_numpy(np.vstack(projected_lidar_list))

--- a/opencda/core/common/coperception_model_manager.py
+++ b/opencda/core/common/coperception_model_manager.py
@@ -13,12 +13,10 @@ import open3d as o3d
 from torch.utils.data import DataLoader  # type: ignore
 
 import opencood.hypes_yaml.yaml_utils as yaml_utils
-import opencood.visualization.simple_plot3d.canvas_3d as canvas_3d
-import opencood.visualization.simple_plot3d.canvas_bev as canvas_bev
 from opencood.tools import train_utils, inference_utils
 from opencood.data_utils.datasets import build_dataset
 from opencood.visualization import vis_utils
-from opencood.utils import box_utils, common_utils, eval_utils
+from opencood.utils import eval_utils
 
 logger = logging.getLogger("cavise.opencda.opencda.core.common.coperception_model_manager")
 
@@ -165,6 +163,10 @@ class CoperceptionVisualizer:
         left_hand: bool = False,
         uncertainty=None,
     ):
+        import opencood.visualization.simple_plot3d.canvas_3d as canvas_3d
+        import opencood.visualization.simple_plot3d.canvas_bev as canvas_bev
+        from opencood.utils import common_utils
+
         config = CoperceptionVisualizer.resolve_visualization_config(visualization_config)
         pc_range = [int(i) for i in pc_range]
         pcd_np, point_colors = CoperceptionVisualizer._get_lidar_points_and_colors(batch_data, pcd, config)
@@ -241,10 +243,17 @@ class CoperceptionVisualizer:
     @staticmethod
     def _to_numpy_points(pcd) -> np.ndarray:
         if isinstance(pcd, list):
+            from opencood.utils import common_utils
+
             pcd_np = [common_utils.torch_tensor_to_numpy(x) for x in pcd]
             pcd_np = pcd_np[0]
         else:
-            pcd_np = common_utils.torch_tensor_to_numpy(pcd) if not isinstance(pcd, np.ndarray) else pcd
+            if isinstance(pcd, np.ndarray):
+                pcd_np = pcd
+            else:
+                from opencood.utils import common_utils
+
+                pcd_np = common_utils.torch_tensor_to_numpy(pcd)
 
         if len(pcd_np.shape) > 2:
             pcd_np = pcd_np[0]
@@ -296,6 +305,8 @@ class CoperceptionVisualizer:
                     continue
 
                 if cav_id != "ego":
+                    from opencood.utils import box_utils
+
                     transformation_matrix = cav_content.get("transformation_matrix")
                     if transformation_matrix is not None:
                         transformation_matrix_np = CoperceptionVisualizer._to_numpy_array(transformation_matrix)
@@ -406,11 +417,8 @@ class CoperceptionModelManager:
             if self.vis is None:
                 self.vis = o3d.visualization.Visualizer()  # noqa: DC05
                 self.vis.create_window()  # noqa: DC05
-                self.vis.get_render_option().background_color = (
-                    np.asarray(  # noqa: DC05
-                        self.visualization_config["background"], dtype=np.float64
-                    )
-                    / 255.0
+                self.vis.get_render_option().background_color = (  # noqa: DC05
+                    np.asarray(self.visualization_config["background"], dtype=np.float64) / 255.0
                 )  # noqa: DC05
                 self.vis.get_render_option().point_size = 1.0  # noqa: DC05
                 self.vis.get_render_option().show_coordinate_frame = True  # noqa: DC05

--- a/opencda/core/common/coperception_model_manager.py
+++ b/opencda/core/common/coperception_model_manager.py
@@ -215,9 +215,6 @@ class CoperceptionVisualizer:
         if vis_gt_box:
             gt_box_np = common_utils.torch_tensor_to_numpy(gt_tensor)
             gt_name = [""] * gt_box_np.shape[0]
-        else:
-            gt_box_np = None
-            gt_name = []
 
         if method == "bev":
             canvas = canvas_bev.Canvas_BEV_heading_right(

--- a/opencda/core/common/coperception_model_manager.py
+++ b/opencda/core/common/coperception_model_manager.py
@@ -1,29 +1,356 @@
+import copy
 import os
 import re
 import logging
+from typing import Any, Dict, Iterable, Mapping, Optional, Tuple
 from tqdm import tqdm
 from collections import OrderedDict
 
+from matplotlib import pyplot as plt
+import numpy as np
 import torch  # type: ignore
 import open3d as o3d
 from torch.utils.data import DataLoader  # type: ignore
 
 import opencood.hypes_yaml.yaml_utils as yaml_utils
+import opencood.visualization.simple_plot3d.canvas_3d as canvas_3d
+import opencood.visualization.simple_plot3d.canvas_bev as canvas_bev
 from opencood.tools import train_utils, inference_utils
 from opencood.data_utils.datasets import build_dataset
-from opencood.visualization import simple_vis, vis_utils
-from opencood.utils import eval_utils
+from opencood.visualization import vis_utils
+from opencood.utils import box_utils, common_utils, eval_utils
 
 logger = logging.getLogger("cavise.opencda.opencda.core.common.coperception_model_manager")
 
 
+class CoperceptionVisualizer:
+    _DEFAULT_VISUALIZATION_CONFIG: Dict[str, Any] = {
+        "background": [0, 0, 0],
+        "lidar_point_colors": {
+            "default": [255, 255, 255],
+            "ego": [80, 255, 80],
+            "attackers": [255, 90, 90],
+            "spoofing": [180, 0, 255],
+        },
+        "bbox_colors": {
+            "gt": [0, 255, 0],
+            "pred": [255, 0, 0],
+            "fake": [180, 0, 255],
+        },
+    }
+
+    @staticmethod
+    def resolve_visualization_config(config: Optional[Mapping[str, Any]] = None) -> Dict[str, Any]:
+        resolved = copy.deepcopy(CoperceptionVisualizer._DEFAULT_VISUALIZATION_CONFIG)
+        if not config:
+            return resolved
+
+        config_dict = dict(config)
+        for key in ("background",):
+            if key in config_dict and config_dict[key] is not None:
+                resolved[key] = list(config_dict[key])
+
+        for key in ("lidar_point_colors", "bbox_colors"):
+            value = config_dict.get(key)
+            if isinstance(value, Mapping):
+                resolved[key].update(dict(value))
+
+        return resolved
+
+    @staticmethod
+    def render_inference_to_file(
+        pred_box_tensor,
+        gt_tensor,
+        pcd,
+        pc_range,
+        save_path,
+        batch_data=None,
+        visualization_config: Optional[Mapping[str, Any]] = None,
+        method: str = "3d",
+        vis_gt_box: bool = True,
+        vis_pred_box: bool = True,
+        left_hand: bool = False,
+        uncertainty=None,
+    ):
+        config = CoperceptionVisualizer.resolve_visualization_config(visualization_config)
+        canvas = CoperceptionVisualizer._build_canvas(
+            pred_box_tensor=pred_box_tensor,
+            gt_tensor=gt_tensor,
+            pcd=pcd,
+            pc_range=pc_range,
+            batch_data=batch_data,
+            visualization_config=config,
+            method=method,
+            vis_gt_box=vis_gt_box,
+            vis_pred_box=vis_pred_box,
+            left_hand=left_hand,
+            uncertainty=uncertainty,
+        )
+        plt.axis("off")
+        plt.imshow(canvas)
+        plt.tight_layout()
+        plt.savefig(save_path, transparent=False, dpi=400, pad_inches=0.0)
+        plt.clf()
+
+    @staticmethod
+    def show_inference_image(
+        pred_box_tensor,
+        gt_tensor,
+        pcd,
+        pc_range,
+        batch_data=None,
+        visualization_config: Optional[Mapping[str, Any]] = None,
+        method: str = "3d",
+        vis_gt_box: bool = True,
+        vis_pred_box: bool = True,
+        left_hand: bool = False,
+        uncertainty=None,
+    ):
+        config = CoperceptionVisualizer.resolve_visualization_config(visualization_config)
+        canvas = CoperceptionVisualizer._build_canvas(
+            pred_box_tensor=pred_box_tensor,
+            gt_tensor=gt_tensor,
+            pcd=pcd,
+            pc_range=pc_range,
+            batch_data=batch_data,
+            visualization_config=config,
+            method=method,
+            vis_gt_box=vis_gt_box,
+            vis_pred_box=vis_pred_box,
+            left_hand=left_hand,
+            uncertainty=uncertainty,
+        )
+        plt.axis("off")
+        plt.imshow(canvas)
+        plt.tight_layout()
+        plt.show()
+        plt.clf()
+
+    @staticmethod
+    def visualize_inference_sample_dataloader(
+        pred_box_tensor,
+        gt_box_tensor,
+        origin_lidar,
+        o3d_pcd,
+        batch_data=None,
+        visualization_config: Optional[Mapping[str, Any]] = None,
+    ):
+        config = CoperceptionVisualizer.resolve_visualization_config(visualization_config)
+        origin_lidar_np, point_colors_uint8 = CoperceptionVisualizer._get_lidar_points_and_colors(batch_data, origin_lidar, config)
+        pred_color = CoperceptionVisualizer._as_float_color(config["bbox_colors"]["pred"])
+        gt_color = CoperceptionVisualizer._as_float_color(config["bbox_colors"]["gt"])
+
+        origin_lidar_np = np.array(origin_lidar_np, copy=True)
+        origin_lidar_np[:, :1] = -origin_lidar_np[:, :1]
+        point_colors = point_colors_uint8.astype(np.float64) / 255.0
+        o3d_pcd.points = o3d.utility.Vector3dVector(origin_lidar_np[:, :3])
+        o3d_pcd.colors = o3d.utility.Vector3dVector(point_colors)
+
+        pred_o3d_box = vis_utils.bbx2linset(pred_box_tensor, color=pred_color) if pred_box_tensor is not None else []
+        gt_o3d_box = vis_utils.bbx2linset(gt_box_tensor, color=gt_color) if gt_box_tensor is not None else []
+
+        return o3d_pcd, pred_o3d_box, gt_o3d_box
+
+    @staticmethod
+    def _build_canvas(
+        pred_box_tensor,
+        gt_tensor,
+        pcd,
+        pc_range,
+        batch_data=None,
+        visualization_config: Optional[Mapping[str, Any]] = None,
+        method: str = "3d",
+        vis_gt_box: bool = True,
+        vis_pred_box: bool = True,
+        left_hand: bool = False,
+        uncertainty=None,
+    ):
+        config = CoperceptionVisualizer.resolve_visualization_config(visualization_config)
+        pc_range = [int(i) for i in pc_range]
+        pcd_np, point_colors = CoperceptionVisualizer._get_lidar_points_and_colors(batch_data, pcd, config)
+        bg_color = CoperceptionVisualizer._as_uint8_color(config["background"])
+        gt_color = CoperceptionVisualizer._as_uint8_color(config["bbox_colors"]["gt"])
+        pred_color = CoperceptionVisualizer._as_uint8_color(config["bbox_colors"]["pred"])
+
+        if vis_pred_box and pred_box_tensor is not None:
+            pred_box_np = common_utils.torch_tensor_to_numpy(pred_box_tensor)
+            pred_name = [""] * pred_box_np.shape[0]
+            if uncertainty is not None:
+                uncertainty_np = common_utils.torch_tensor_to_numpy(uncertainty)
+                uncertainty_np = np.exp(uncertainty_np)
+                d_a_square = 1.6**2 + 3.9**2
+
+                if uncertainty_np.shape[1] == 3:
+                    uncertainty_np[:, :2] *= d_a_square
+                    uncertainty_np = np.sqrt(uncertainty_np)
+                    pred_name = [
+                        f"x_u:{uncertainty_np[i, 0]:.3f} y_u:{uncertainty_np[i, 1]:.3f} a_u:{uncertainty_np[i, 2]:.3f}"
+                        for i in range(uncertainty_np.shape[0])
+                    ]
+                elif uncertainty_np.shape[1] == 2:
+                    uncertainty_np[:, :2] *= d_a_square
+                    uncertainty_np = np.sqrt(uncertainty_np)
+                    pred_name = [f"x_u:{uncertainty_np[i, 0]:.3f} y_u:{uncertainty_np[i, 1]:3f}" for i in range(uncertainty_np.shape[0])]
+                elif uncertainty_np.shape[1] == 7:
+                    uncertainty_np[:, :2] *= d_a_square
+                    uncertainty_np = np.sqrt(uncertainty_np)
+                    pred_name = [
+                        f"x_u:{uncertainty_np[i, 0]:.3f} y_u:{uncertainty_np[i, 1]:3f} a_u:{uncertainty_np[i, 6]:3f}"
+                        for i in range(uncertainty_np.shape[0])
+                    ]
+        else:
+            pred_box_np = None
+            pred_name = []
+
+        if vis_gt_box:
+            gt_box_np = common_utils.torch_tensor_to_numpy(gt_tensor)
+            gt_name = [""] * gt_box_np.shape[0]
+        else:
+            gt_box_np = None
+            gt_name = []
+
+        if method == "bev":
+            canvas = canvas_bev.Canvas_BEV_heading_right(
+                canvas_shape=((pc_range[4] - pc_range[1]) * 10, (pc_range[3] - pc_range[0]) * 10),
+                canvas_x_range=(pc_range[0], pc_range[3]),
+                canvas_y_range=(pc_range[1], pc_range[4]),
+                canvas_bg_color=bg_color,
+                left_hand=left_hand,
+            )
+            canvas_xy, valid_mask = canvas.get_canvas_coords(pcd_np)
+            if valid_mask.any():
+                canvas.draw_canvas_points(canvas_xy[valid_mask], colors=point_colors[valid_mask])
+            if vis_gt_box and gt_box_np is not None:
+                canvas.draw_boxes(gt_box_np, colors=gt_color, texts=gt_name, box_line_thickness=5)
+            if vis_pred_box and pred_box_np is not None:
+                canvas.draw_boxes(pred_box_np, colors=pred_color, texts=pred_name, box_line_thickness=5)
+        elif method == "3d":
+            canvas = canvas_3d.Canvas_3D(canvas_bg_color=bg_color, left_hand=left_hand)
+            canvas_xy, valid_mask = canvas.get_canvas_coords(pcd_np)
+            if valid_mask.any():
+                canvas.draw_canvas_points(canvas_xy[valid_mask], colors=point_colors[valid_mask])
+            if vis_gt_box and gt_box_np is not None:
+                canvas.draw_boxes(gt_box_np, colors=gt_color, texts=gt_name)
+            if vis_pred_box and pred_box_np is not None:
+                canvas.draw_boxes(pred_box_np, colors=pred_color, texts=pred_name)
+        else:
+            raise ValueError(f"Unsupported visualization method: {method}")
+
+        return canvas.canvas
+
+    @staticmethod
+    def _to_numpy_points(pcd) -> np.ndarray:
+        if isinstance(pcd, list):
+            pcd_np = [common_utils.torch_tensor_to_numpy(x) for x in pcd]
+            pcd_np = pcd_np[0]
+        else:
+            pcd_np = common_utils.torch_tensor_to_numpy(pcd) if not isinstance(pcd, np.ndarray) else pcd
+
+        if len(pcd_np.shape) > 2:
+            pcd_np = pcd_np[0]
+        if pcd_np.shape[1] > 4:
+            pcd_np = pcd_np[:, 1:]
+        return np.array(pcd_np, copy=True)
+
+    @staticmethod
+    def _get_lidar_points_and_colors(batch_data, fallback_pcd, config: Mapping[str, Any]) -> Tuple[np.ndarray, np.ndarray]:
+        default_color = CoperceptionVisualizer._as_uint8_color(config["lidar_point_colors"]["default"])
+        ego_color = CoperceptionVisualizer._as_uint8_color(config["lidar_point_colors"].get("ego", default_color))
+
+        if isinstance(batch_data, Mapping):
+            ego_entry = batch_data.get("ego")
+            if isinstance(ego_entry, Mapping) and "origin_lidar_by_agent" in ego_entry:
+                points_by_agent = ego_entry["origin_lidar_by_agent"]
+                roles = list(ego_entry.get("origin_lidar_roles", []))
+                agent_ids = list(ego_entry.get("origin_lidar_agent_ids", []))
+                colored_points = []
+                colored_values = []
+
+                for idx, points in enumerate(points_by_agent):
+                    agent_points = CoperceptionVisualizer._to_numpy_points(points)
+                    if agent_points.size == 0:
+                        continue
+
+                    role = roles[idx] if idx < len(roles) else "default"
+                    agent_id = agent_ids[idx] if idx < len(agent_ids) else None
+                    color = CoperceptionVisualizer._resolve_point_color(
+                        config, agent_id=agent_id, role=role, default_color=default_color, ego_color=ego_color
+                    )
+                    colored_points.append(agent_points)
+                    colored_values.append(np.tile(np.asarray(color, dtype=np.uint8), (agent_points.shape[0], 1)))
+
+                if colored_points:
+                    return np.vstack(colored_points), np.vstack(colored_values)
+
+            colored_points = []
+            colored_values = []
+            for cav_id, cav_content in batch_data.items():
+                if not isinstance(cav_content, Mapping):
+                    continue
+                local_lidar = cav_content.get("origin_lidar_local")
+                if local_lidar is None:
+                    continue
+
+                cav_points = CoperceptionVisualizer._to_numpy_points(local_lidar)
+                if cav_points.size == 0:
+                    continue
+
+                if cav_id != "ego":
+                    transformation_matrix = cav_content.get("transformation_matrix")
+                    if transformation_matrix is not None:
+                        transformation_matrix_np = CoperceptionVisualizer._to_numpy_array(transformation_matrix)
+                        cav_points[:, :3] = box_utils.project_points_by_matrix_torch(cav_points[:, :3], transformation_matrix_np)
+
+                cav_color = CoperceptionVisualizer._resolve_point_color(
+                    config, agent_id=cav_id, role="ego" if cav_id == "ego" else "default", default_color=default_color, ego_color=ego_color
+                )
+                colored_points.append(cav_points)
+                colored_values.append(np.tile(np.asarray(cav_color, dtype=np.uint8), (cav_points.shape[0], 1)))
+
+            if colored_points:
+                return np.vstack(colored_points), np.vstack(colored_values)
+
+        fallback_points = CoperceptionVisualizer._to_numpy_points(fallback_pcd)
+        fallback_colors = np.tile(np.asarray(default_color, dtype=np.uint8), (fallback_points.shape[0], 1))
+        return fallback_points, fallback_colors
+
+    @staticmethod
+    def _as_uint8_color(color: Iterable[Any]) -> Tuple[int, int, int]:
+        rgb = [int(v) for v in list(color)[:3]]
+        return tuple(max(0, min(255, value)) for value in rgb)
+
+    @staticmethod
+    def _as_float_color(color: Iterable[Any]) -> Tuple[float, float, float]:
+        return tuple(channel / 255.0 for channel in CoperceptionVisualizer._as_uint8_color(color))
+
+    @staticmethod
+    def _resolve_point_color(config: Mapping[str, Any], agent_id, role: str, default_color, ego_color):
+        lidar_point_colors = config["lidar_point_colors"]
+        if agent_id is not None and agent_id in lidar_point_colors:
+            return CoperceptionVisualizer._as_uint8_color(lidar_point_colors[agent_id])
+        if role == "ego":
+            return ego_color
+        return default_color
+
+    @staticmethod
+    def _to_numpy_array(value):
+        if isinstance(value, np.ndarray):
+            return np.array(value, copy=True)
+
+        if hasattr(value, "detach"):
+            return value.detach().cpu().numpy()
+
+        return np.array(value, copy=True)
+
+
 class CoperceptionModelManager:
-    def __init__(self, opt, current_time, payload_handler=None):
+    def __init__(self, opt, current_time, payload_handler=None, visualization_config=None):
         self.opt = opt
         self.hypes = yaml_utils.load_yaml(None, self.opt)
         self.model = train_utils.create_model(self.hypes)
         self.current_time = current_time
         self.vis = None
+        self.visualization_config = CoperceptionVisualizer.resolve_visualization_config(visualization_config)
 
         if torch.cuda.is_available():
             self.model.cuda()
@@ -79,7 +406,12 @@ class CoperceptionModelManager:
             if self.vis is None:
                 self.vis = o3d.visualization.Visualizer()  # noqa: DC05
                 self.vis.create_window()  # noqa: DC05
-                self.vis.get_render_option().background_color = [0.05, 0.05, 0.05]  # noqa: DC05
+                self.vis.get_render_option().background_color = (
+                    np.asarray(  # noqa: DC05
+                        self.visualization_config["background"], dtype=np.float64
+                    )
+                    / 255.0
+                )  # noqa: DC05
                 self.vis.get_render_option().point_size = 1.0  # noqa: DC05
                 self.vis.get_render_option().show_coordinate_frame = True  # noqa: DC05
             # used to visualize lidar points
@@ -134,32 +466,52 @@ class CoperceptionModelManager:
                         vis_dir = f"simulation_output/coperception/vis_{mode}/{self.opt.test_scenario}_{self.current_time}"
                         os.makedirs(vis_dir, exist_ok=True)
                         vis_save_path = os.path.join(vis_dir, f"{mode}_{tick_number:05d}.png")
-                        simple_vis.visualize(
+                        CoperceptionVisualizer.render_inference_to_file(
                             pred_box_tensor,
                             gt_box_tensor,
                             pcd_points,
                             self.hypes["postprocess"]["gt_range"],
                             vis_save_path,
+                            batch_data=batch_data,
+                            visualization_config=self.visualization_config,
                             method=mode,
                             left_hand=True,
                             vis_pred_box=True,
                         )
 
                 if self.opt.show_vis:
-                    vis_save_path = ""
-                    self.opencood_dataset.visualize_result(
-                        pred_box_tensor,
-                        gt_box_tensor,
-                        batch_data["ego"]["origin_lidar"],
-                        self.opt.show_vis,
-                        vis_save_path,
-                        dataset=self.opencood_dataset,
-                    )
+                    if self.hypes["postprocess"]["core_method"] == "BevPostprocessor":
+                        CoperceptionVisualizer.show_inference_image(
+                            pred_box_tensor,
+                            gt_box_tensor,
+                            batch_data["ego"]["origin_lidar"],
+                            self.hypes["postprocess"]["gt_range"],
+                            batch_data=batch_data,
+                            visualization_config=self.visualization_config,
+                            method="bev",
+                            left_hand=True,
+                        )
+                    else:
+                        CoperceptionVisualizer.show_inference_image(
+                            pred_box_tensor,
+                            gt_box_tensor,
+                            batch_data["ego"]["origin_lidar"],
+                            self.hypes["postprocess"]["gt_range"],
+                            batch_data=batch_data,
+                            visualization_config=self.visualization_config,
+                            method="3d",
+                            left_hand=True,
+                        )
 
                 if self.opt.show_sequence and pred_box_tensor is not None and self.hypes["postprocess"]["core_method"] != "BevPostprocessor":
                     self.vis.clear_geometries()
-                    pcd, pred_o3d_box, gt_o3d_box = vis_utils.visualize_inference_sample_dataloader(
-                        pred_box_tensor, gt_box_tensor, batch_data["ego"]["origin_lidar"], vis_pcd, mode="constant"
+                    pcd, pred_o3d_box, gt_o3d_box = CoperceptionVisualizer.visualize_inference_sample_dataloader(
+                        pred_box_tensor,
+                        gt_box_tensor,
+                        batch_data["ego"]["origin_lidar"],
+                        vis_pcd,
+                        batch_data=batch_data,
+                        visualization_config=self.visualization_config,
                     )
                     if i == 0:
                         self.vis.add_geometry(pcd)

--- a/opencda/core/common/test/test_coperception_model_manager.py
+++ b/opencda/core/common/test/test_coperception_model_manager.py
@@ -3,10 +3,11 @@ from collections import OrderedDict
 import pytest
 from unittest.mock import MagicMock, patch
 from pathlib import Path
+import numpy as np
 
 # The production code imports are now safe because pytest_configure in conftest.py
 # installs the mocks before collection.
-from opencda.core.common.coperception_model_manager import CoperceptionModelManager, DirectoryProcessor
+from opencda.core.common.coperception_model_manager import CoperceptionModelManager, CoperceptionVisualizer, DirectoryProcessor
 
 
 class DummyOpt:
@@ -250,14 +251,17 @@ class TestCoperceptionModelManager:
         manager.opencood_dataset = MagicMock()
         manager_deps["inference_utils"].inference_late_fusion.return_value = ("p", "s", "g")
 
-        manager.make_prediction(5)
+        with patch.object(CoperceptionVisualizer, "render_inference_to_file") as mock_render:
+            manager.make_prediction(5)
 
         # Verify directories
         base_dir = tmp_path / "simulation_output/coperception"
         assert (base_dir / "vis_3d/scen1_2023_01_01").exists()
         assert (base_dir / "vis_bev/scen1_2023_01_01").exists()
 
-        assert manager_deps["simple_vis"].visualize.call_count == 2
+        assert mock_render.call_count == 2
+        assert mock_render.call_args_list[0].kwargs["method"] == "3d"
+        assert mock_render.call_args_list[1].kwargs["method"] == "bev"
 
     def test_make_prediction_show_sequence(self, manager_deps, fake_heavy_deps):
         """Test Open3D interactions without opening windows."""
@@ -271,7 +275,12 @@ class TestCoperceptionModelManager:
         # Ensure pred is not None
         manager_deps["inference_utils"].inference_late_fusion.return_value = ("box", "score", "gt")
 
-        manager.make_prediction(0)
+        with patch.object(
+            CoperceptionVisualizer,
+            "visualize_inference_sample_dataloader",
+            return_value=(MagicMock(name="pcd"), [MagicMock(name="pred_box")], [MagicMock(name="gt_box")]),
+        ) as mock_visualize:
+            manager.make_prediction(0)
 
         # Check Visualizer creation (mocked class in conftest)
         manager_deps["Visualizer"].assert_called()
@@ -280,6 +289,7 @@ class TestCoperceptionModelManager:
         vis_instance.create_window.assert_called()
         vis_instance.add_geometry.assert_called()  # i=0
         vis_instance.update_renderer.assert_called()
+        mock_visualize.assert_called_once()
 
         # Verify line set assignment was called
         manager_deps["vis_utils"].linset_assign_list.assert_called()
@@ -301,6 +311,75 @@ class TestCoperceptionModelManager:
         assert args[0] is manager.final_result_stat
         assert Path(args[1]).resolve() == expected_dir.resolve()
         assert args[2] == opt.global_sort_detections
+
+
+class TestCoperceptionVisualizer:
+    def test_resolve_visualization_config_merges_defaults_and_overrides(self):
+        config = CoperceptionVisualizer.resolve_visualization_config(
+            {
+                "background": [12, 18, 24],
+                "lidar_point_colors": {
+                    "default": [200, 200, 200],
+                    "cav-2": [10, 20, 30],
+                },
+                "bbox_colors": {"pred": [1, 2, 3]},
+            }
+        )
+
+        assert config["background"] == [12, 18, 24]
+        assert config["lidar_point_colors"]["default"] == [200, 200, 200]
+        assert config["lidar_point_colors"]["ego"] == [80, 255, 80]
+        assert config["lidar_point_colors"]["cav-2"] == [10, 20, 30]
+        assert config["bbox_colors"]["pred"] == [1, 2, 3]
+        assert config["bbox_colors"]["gt"] == [0, 255, 0]
+
+    def test_get_lidar_points_and_colors_keeps_agent_order_and_applies_id_override(self):
+        config = CoperceptionVisualizer.resolve_visualization_config(
+            {
+                "lidar_point_colors": {
+                    "default": [200, 200, 200],
+                    "ego": [10, 250, 10],
+                    "cav-2": [90, 80, 70],
+                }
+            }
+        )
+        batch_data = {
+            "ego": {
+                "origin_lidar_by_agent": [
+                    np.array([[1.0, 0.0, 0.0, 1.0]]),
+                    np.array([[2.0, 0.0, 0.0, 1.0], [3.0, 0.0, 0.0, 1.0]]),
+                ],
+                "origin_lidar_roles": ["ego", "other"],
+                "origin_lidar_agent_ids": ["cav-1", "cav-2"],
+            }
+        }
+
+        points, colors = CoperceptionVisualizer._get_lidar_points_and_colors(batch_data, None, config)
+
+        assert points.tolist() == [[1.0, 0.0, 0.0, 1.0], [2.0, 0.0, 0.0, 1.0], [3.0, 0.0, 0.0, 1.0]]
+        assert colors.tolist() == [[10, 250, 10], [90, 80, 70], [90, 80, 70]]
+
+    def test_get_lidar_points_and_colors_prefers_agent_id_override_over_ego_role(self):
+        config = CoperceptionVisualizer.resolve_visualization_config(
+            {
+                "lidar_point_colors": {
+                    "default": [255, 255, 255],
+                    "ego": [80, 255, 80],
+                    "cav-1": [123, 45, 67],
+                }
+            }
+        )
+        batch_data = {
+            "ego": {
+                "origin_lidar_by_agent": [np.array([[1.0, 2.0, 3.0, 1.0]])],
+                "origin_lidar_roles": ["ego"],
+                "origin_lidar_agent_ids": ["cav-1"],
+            }
+        }
+
+        _, colors = CoperceptionVisualizer._get_lidar_points_and_colors(batch_data, None, config)
+
+        assert colors.tolist() == [[123, 45, 67]]
 
 
 # --- Tests for DirectoryProcessor ---

--- a/opencda/scenario_testing/config_yaml/1551_carla_cavs.yaml
+++ b/opencda/scenario_testing/config_yaml/1551_carla_cavs.yaml
@@ -145,3 +145,21 @@ scenario:
       spawn_position: [50, 135.792358, 0.3, 0, 0, 0]
       destination: [200, 135.792358, 0.3]
       id: 9
+
+cooperative_perception_visualization:
+  background: [10, 14, 24]
+  lidar_point_colors:
+    default: [214, 220, 229]
+    cav-1: [111, 214, 255]
+    cav-2: [127, 236, 173]
+    cav-3: [255, 207, 119]
+    cav-4: [255, 154, 162]
+    cav-5: [199, 166, 255]
+    cav-6: [123, 206, 190]
+    cav-7: [245, 186, 110]
+    cav-8: [255, 214, 232]
+    cav-9: [181, 225, 140]
+
+  bbox_colors:
+    gt: [88, 221, 154]
+    pred: [255, 117, 117]

--- a/opencda/scenario_testing/config_yaml/default.yaml
+++ b/opencda/scenario_testing/config_yaml/default.yaml
@@ -18,7 +18,6 @@ world:
     fog_falloff: 0 # Density of the fog (as in specific mass) from 0 to infinity. The bigger the value, the more dense and heavy it will be, and the fog will reach smaller heights
     wetness: 0
 
-
 # Define the basic parameters of the rsu
 rsu_base:
   sensing:
@@ -205,3 +204,17 @@ platoon_base:
 # scenario:
 #   single_cav_list: []
 #   platoon_list: []
+
+cooperative_perception_visualization:
+  background: [0, 0, 0]
+  lidar_point_colors:
+    default: [255, 255, 255] # fallback color for all lidar points; in general CoP visualization every non-ego agent also uses this color
+    ego: [80, 255, 80] # used when the visualizer can identify ego points
+    attackers: [255, 90, 90] # reserved for real lidar points of attacking agents; not used in the general CoP visualization yet
+    spoofing: [180, 0, 255] # reserved for fake/spoofed lidar points injected by AdvCP; not used in the general CoP visualization yet
+    # cav-1: [255, 220, 0] # optional explicit color override for a specific vehicle id
+    # rsu-2: [0, 200, 255] # optional explicit color override for a specific RSU id
+  bbox_colors:
+    gt: [0, 255, 0]
+    pred: [255, 0, 0]
+    fake: [180, 0, 255]  # works only when AdvCP is enabled

--- a/opencda/scenario_testing/scenario.py
+++ b/opencda/scenario_testing/scenario.py
@@ -131,7 +131,16 @@ class Scenario:
                     logger.error(f'Model directory "{opt.model_dir}" does not exist.')
                     sys.exit(1)
 
-                self.coperception_model_manager = CoperceptionModelManager(opt=opt, current_time=current_time, payload_handler=self.payload_handler)
+                cp_vis_config = omegaconf.OmegaConf.to_container(
+                    scenario_params.get("cooperative_perception_visualization", {}),
+                    resolve=True,
+                )
+                self.coperception_model_manager = CoperceptionModelManager(
+                    opt=opt,
+                    current_time=current_time,
+                    payload_handler=self.payload_handler,
+                    visualization_config=cp_vis_config,
+                )
                 logger.info("created cooperception manager")
 
         if opt.with_aim:

--- a/opencda/scenario_testing/scenario.py
+++ b/opencda/scenario_testing/scenario.py
@@ -38,12 +38,10 @@ class Scenario:
     scenario_manager: sim_api.ScenarioManager | sim_api.CoScenarioManager
     single_cav_list: list[VehicleManager]
     rsu_list: list[RSUManager]
-    # TODO: find spectator type
     spectator: carla.Actor
     cav_world: CavWorld
     codriving_model_manager: AIMModelManager  # [CoDrivingInt]
     platoon_list: list[PlatooningManager]
-    # TODO: find bg cars type
     bg_veh_list: list[carla.Actor]
     scenario_name: str
 


### PR DESCRIPTION
This PR adds scenario-level configuration for cooperative perception visualization.

It introduces a new `cooperative_perception_visualization` section in scenario YAMLs, allowing users to customize:
- background color
- lidar point colors
- GT bounding box color
- predicted bounding box color
- fake bounding box color for AdvCP-related visualization

The visualization pipeline now supports:
- consistent color customization for late, early, and intermediate fusion modes
- explicit coloring of ego lidar points
- explicit coloring by runtime agent id such as `cav-1` and `rsu-2`

Also, there are reserved config keys for future AdvCP-specific rendering:
- attackers
- spoofing
- bbox_colors.fake

At this stage:
- default, ego, and per-agent id colors are active in the general cooperative perception visualization
- `attackers`, `spoofing`, and `bbox_colors.fake` are added as forward-compatible placeholders for AdvCP-specific visualization and are not yet used in the generic rendering path

The visualization logic was also consolidated into CoperceptionModelManager, so cooperative perception rendering is now managed close to the inference pipeline.

## Example
```yaml
cooperative_perception_visualization:
  background: [0, 0, 0]
  lidar_point_colors:
    default: [255, 255, 255] # fallback color for all lidar points; in general CoP visualization every non-ego agent also uses this color
    ego: [80, 255, 80] # used when the visualizer can identify ego points
    attackers: [255, 90, 90] # reserved for real lidar points of attacking agents; not used in the general CoP visualization yet
    spoofing: [180, 0, 255] # reserved for fake/spoofed lidar points injected by AdvCP; not used in the general CoP visualization yet
    # cav-1: [255, 220, 0] # optional explicit color override for a specific vehicle id
    # rsu-2: [0, 200, 255] # optional explicit color override for a specific RSU id
  bbox_colors:
    gt: [0, 255, 0]
    pred: [255, 0, 0]
    fake: [180, 0, 255] # works only when AdvCP is enabled
```

## Visualize example
<img width="2431" height="1213" alt="first" src="https://github.com/user-attachments/assets/18c2ed01-5fa4-490c-9ed4-5e3b04ed1d3f" />

<img width="2434" height="1213" alt="second" src="https://github.com/user-attachments/assets/bfb1eb7b-d83b-4442-b34c-f7460dfb6e73" />

<img width="2433" height="653" alt="third" src="https://github.com/user-attachments/assets/9f940cec-25f4-49c9-9322-f293cb6cf117" />
