### PR TITLE
[serivces] Add priority to services

### DIFF
--- a/opencda/core/application/behavior/behavior_service_protocol.py
+++ b/opencda/core/application/behavior/behavior_service_protocol.py
@@ -15,6 +15,7 @@ class BehaviorService(Protocol[BehaviorServiceRequestT, BehaviorServiceResponseT
     """Protocol implemented by any behavior service attached to a participant."""
 
     service_name: str
+    priority: int = 100  # Less is better
 
     def on_attach(self, owner: Any) -> None:
         """Initialize the service for a particular participant instance."""

--- a/opencda/core/application/behavior/services/aim_client/service.py
+++ b/opencda/core/application/behavior/services/aim_client/service.py
@@ -27,14 +27,14 @@ class AIMClient:
     """Behavior service that runs AIM predictions for a batch of CAV requests."""
 
     service_name = "aim_client"
+    priority = 20
 
-    def __init__(
-        self,
-    ) -> None:
+    def __init__(self, priority: int = 20) -> None:
         """
         Initialize the AIM-backed behavior service.
         """
         self._owner_ref: weakref.ReferenceType[VehicleManager] | None = None
+        self.priority = priority
 
     def _get_owner(self) -> VehicleManager:
         owner_ref = self._owner_ref

--- a/opencda/core/application/behavior/services/aim_server/service.py
+++ b/opencda/core/application/behavior/services/aim_server/service.py
@@ -25,9 +25,11 @@ class AIMServer:
     """Behavior service that runs AIM predictions for a batch of CAV requests."""
 
     service_name = "aim_server"
+    priority = 20
 
     def __init__(
         self,
+        priority: int = 20,
         **aim_config: Any,
     ) -> None:
         """
@@ -40,6 +42,7 @@ class AIMServer:
         """
         self._owner_ref: weakref.ReferenceType[RSUManager] | None = None
         self.aim_model_manager: AIMModelManager | None = None
+        self.priority = priority
 
         aim_model_name = cast(str, aim_config.pop("model", "MTP"))
         self.model = get_model(aim_model_name, **aim_config)

--- a/opencda/core/application/behavior/services/dummy_service/service.py
+++ b/opencda/core/application/behavior/services/dummy_service/service.py
@@ -20,13 +20,12 @@ class DummyService:
     """A trivial service that echoes back text with a small modification."""
 
     service_name = "dummy_service"
+    priority = 90
 
-    def __init__(
-        self,
-        response_suffix: str = " [dummy processed]",
-    ) -> None:
+    def __init__(self, priority: int = 90, response_suffix: str = " [dummy processed]") -> None:
         self._response_suffix = response_suffix
         self._owner_ref: weakref.ReferenceType[Any] | None = None
+        self.priority = priority
 
     def _get_owner(self) -> Any:
         owner_ref = self._owner_ref

--- a/opencda/core/application/behavior/services/movement_controller/service.py
+++ b/opencda/core/application/behavior/services/movement_controller/service.py
@@ -23,14 +23,14 @@ class MovementController:
     """Behavior service that runs AIM predictions for a batch of CAV requests."""
 
     service_name = "movement_controller"
+    priority = 100
 
-    def __init__(
-        self,
-    ) -> None:
+    def __init__(self, priority: int = 100) -> None:
         """
         Initialize the AIM-backed behavior service.
         """
         self._owner_ref: weakref.ReferenceType[VehicleManager] | None = None
+        self.priority = priority
 
     def _get_owner(self) -> VehicleManager:
         owner_ref = self._owner_ref

--- a/opencda/core/common/rsu_manager.py
+++ b/opencda/core/common/rsu_manager.py
@@ -149,7 +149,8 @@ class RSUManager(object):
             if service_type is None:
                 raise ValueError("Each behavior service config must define 'type'.")
 
-            behavior_services.append(create_service(service_name=service_type, **service_config_dict))
+            service = create_service(service_name=service_type, **service_config_dict)
+            behavior_services.append(service)
             logger.info("Attached behavior service '%s' to RSU %r.", service_type, self.id)
 
         return behavior_services
@@ -157,7 +158,7 @@ class RSUManager(object):
     def __set_behavior_services(self, behavior_services: Optional[Iterable[BehaviorService[Any, Any]]]) -> None:
         services = tuple(behavior_services or ())
         self.__validate_behavior_services(services)
-        self.behavior_services = services
+        self.behavior_services = tuple(sorted(services, key=lambda service: service.priority))
         self.behavior_service_results: list[TransportMessage] = []
         self._behavior_services_by_name = {service.service_name: service for service in self.behavior_services}
 
@@ -171,6 +172,9 @@ class RSUManager(object):
             service_name = service.service_name
             if service_name in seen_service_names:
                 raise ValueError(f"Duplicate behavior service ID detected: {service_name!r}.")
+
+            if not isinstance(service.priority, int):
+                raise TypeError(f"Behavior service {service_name!r} must define an integer priority; got {type(service.priority).__name__!r}.")
 
             seen_service_names.add(service_name)
 

--- a/opencda/core/common/vehicle_manager.py
+++ b/opencda/core/common/vehicle_manager.py
@@ -208,7 +208,7 @@ class VehicleManager(object):
     def __set_behavior_services(self, behavior_services: Optional[Iterable[BehaviorService[Any, Any]]]) -> None:
         services = tuple(behavior_services or ())
         self.__validate_behavior_services(services)
-        self.behavior_services = services
+        self.behavior_services = tuple(sorted(services, key=lambda service: service.priority))
         self.behavior_service_results: list[TransportMessage] = []
         self._behavior_services_by_name = {service.service_name: service for service in self.behavior_services}
 
@@ -222,6 +222,9 @@ class VehicleManager(object):
             service_name = service.service_name
             if service_name in seen_service_ids:
                 raise ValueError(f"Duplicate behavior service ID detected: {service_name!r}.")
+
+            if not isinstance(service.priority, int):
+                raise TypeError(f"Behavior service {service_name!r} must define an integer priority; got {type(service.priority).__name__!r}.")
 
             seen_service_ids.add(service_name)
 


### PR DESCRIPTION
Add priority-aware ordering for behavior services. Services are now initialized and processed in ascending `priority` order, so lower numeric values run first.