### PR TITLE
[AIM] Integrates AIM trajectory outputs directly into the OpenCDA movement control flow

### DIFF
--- a/opencda/core/actuation/control_manager.py
+++ b/opencda/core/actuation/control_manager.py
@@ -4,12 +4,11 @@ Controller interface
 
 from __future__ import annotations
 import importlib
-import carla
 
 from typing import TYPE_CHECKING, Mapping, Any
 
 if TYPE_CHECKING:
-    from opencda.core.application.behavior.types import Location, Transform
+    import carla
 
 
 class ControlManager(object):
@@ -33,13 +32,13 @@ class ControlManager(object):
         controller = getattr(importlib.import_module(f"opencda.core.actuation.{controller_type}"), "Controller")
         self.controller = controller(control_config["args"])
 
-    def update_info(self, ego_pos: Transform, ego_speed: float) -> None:
+    def update_info(self, ego_pos: carla.Transform, ego_speed: float) -> None:
         """
         Update ego vehicle information for controller.
         """
         self.controller.update_info(ego_pos, ego_speed)
 
-    def run_step(self, target_speed: float, target_location: Location) -> carla.VehicleControl:
+    def run_step(self, target_speed: float, target_location: carla.Location) -> carla.VehicleControl:
         """
         Execute current controller step.
         """

--- a/opencda/core/application/behavior/services/aim_client/service.py
+++ b/opencda/core/application/behavior/services/aim_client/service.py
@@ -4,18 +4,22 @@ from __future__ import annotations
 
 import weakref
 import logging
+from collections import deque
 from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
 import traci
+import carla
 
 from opencda.core.application.behavior.registry import BehaviorServiceRegistry
 from opencda.core.application.behavior.transport_message import TransportMessage
 from opencda.core.application.behavior.services.aim_server import AIMServerRequest, AIMServerResponse
 from opencda.core.application.behavior.services.movement_controller import MovementControllerRequestMessage
-from opencda.core.application.behavior.types import Rotation, Transform
+
+from .utils import get_speed, draw_trajetory_points, calculate_target_speeds
 
 if TYPE_CHECKING:
+    from opencda.core.application.behavior.types import Location
     from opencda.core.common.vehicle_manager import VehicleManager
 
 
@@ -26,15 +30,17 @@ logger = logging.getLogger("cavise.opencda.opencda.core.application.behavior.ser
 class AIMClient:
     """Behavior service that runs AIM predictions for a batch of CAV requests."""
 
-    service_name = "aim_client"
-    priority = 20
+    service_name: str = "aim_client"
+    priority: int = 20
 
-    def __init__(self, priority: int = 20) -> None:
+    def __init__(self, priority: int = 20, debug: bool = False) -> None:
         """
         Initialize the AIM-backed behavior service.
         """
         self._owner_ref: weakref.ReferenceType[VehicleManager] | None = None
         self.priority = priority
+        self.trajectory: deque[tuple[Location, float]] = deque()
+        self.debug = debug
 
     def _get_owner(self) -> VehicleManager:
         owner_ref = self._owner_ref
@@ -70,9 +76,23 @@ class AIMClient:
         owner = self._get_owner()
         res_messages: list[TransportMessage[MovementControllerRequestMessage | AIMServerRequest]] = []
 
+        current_location = owner.vehicle.get_location()
+        current_speed = get_speed(owner.vehicle)
         for message in self._filter_messages(messages):
-            target_position = Transform(message.next_position, Rotation(0, 0, 0))
-            payload = MovementControllerRequestMessage(target_position=target_position)
+            control_trajectory = message.trajectory[1:]  # drop first because it was calculated on previous tick
+            target_speeds = calculate_target_speeds(control_trajectory, 0.05, current_location, current_speed, 111, 2.5, 4.5)
+            self.trajectory = deque(zip(control_trajectory, target_speeds))
+            if self.debug:
+                draw_trajetory_points(
+                    owner.agent._local_planner._vehicle.get_world(),
+                    control_trajectory,
+                    size=0.05,
+                    color=carla.Color(255, 0, 0),
+                    life_time=0.1,
+                    _map=owner.agent._map,
+                )
+            target_location, target_speed = self.trajectory.popleft()
+            payload = MovementControllerRequestMessage(target_location=target_location, target_speed=target_speed)
             res_messages.append(
                 TransportMessage(
                     src_owner_id=owner.id,
@@ -82,12 +102,9 @@ class AIMClient:
                     payload=payload,
                 )
             )
-        if len(res_messages) == 0:
-            end_waypoint = owner.agent.end_waypoint
-            if end_waypoint is None:
-                raise RuntimeError("AIM client requires a valid end waypoint when no AIM response is available.")
-            target_position = Transform(end_waypoint.transform.location, Rotation(0, 0, 0))
-            payload = MovementControllerRequestMessage(target_position=target_position)
+        if len(res_messages) == 0 and self.trajectory:
+            target_location, target_speed = self.trajectory.popleft()
+            payload = MovementControllerRequestMessage(target_location=target_location, target_speed=target_speed)
             res_messages.append(
                 TransportMessage(
                     src_owner_id=owner.id,

--- a/opencda/core/application/behavior/services/aim_client/utils.py
+++ b/opencda/core/application/behavior/services/aim_client/utils.py
@@ -1,0 +1,143 @@
+import carla
+import math
+from collections.abc import Sequence
+from opencda.core.application.behavior.types import Location
+
+
+def get_speed(vehicle: carla.Vehicle, meters: bool = False) -> float:
+    """
+    Compute speed of a vehicle in Km/h.
+
+    Parameters
+    ----------
+    meters : bool
+        Whether to use m/s (True) or km/h (False).
+
+    vehicle : carla.vehicle
+        The vehicle for which speed is calculated.
+
+    Returns
+    -------
+    speed : float
+        The vehicle speed.
+    """
+    vel = vehicle.get_velocity()
+    vel_meter_per_second = math.sqrt(vel.x**2 + vel.y**2 + vel.z**2)
+    return vel_meter_per_second if meters else 3.6 * vel_meter_per_second
+
+
+def calculate_target_speeds(
+    trajectory: Sequence[Location],
+    dt: float = 0.1,
+    current_location: Location | carla.Location | None = None,
+    current_speed: float | None = None,
+    max_speed: float | None = None,
+    max_accel: float | None = None,
+    max_decel: float | None = None,
+) -> list[float]:
+    """
+    Calculate per-point target speeds for a timed AIM trajectory.
+
+    Parameters
+    ----------
+    trajectory : Sequence[Location]
+        Predicted trajectory points in meters.
+
+    dt : float
+        Time delta between two predicted trajectory points, in seconds.
+        The original AIM inference examples use 0.1 s.
+
+    current_location : Location | carla.Location | None
+        Current ego location. If provided, the speed for the first trajectory
+        point is calculated from ego location to trajectory[0].
+
+    current_speed : float | None
+        Current ego speed in km/h. Used only for acceleration limiting.
+
+    max_speed : float | None
+        Optional speed cap in km/h.
+
+    max_accel : float | None
+        Optional acceleration cap in m/s^2.
+
+    max_decel : float | None
+        Optional deceleration cap in m/s^2. Pass a positive value.
+
+    Returns
+    -------
+    list[float]
+        Target speed for each trajectory point in km/h.
+    """
+    if dt <= 0:
+        raise ValueError("dt must be positive.")
+
+    if not trajectory:
+        return []
+
+    speeds: list[float] = []
+    previous_location = current_location
+    previous_speed = current_speed
+
+    for index, location in enumerate(trajectory):
+        if previous_location is None:
+            if len(trajectory) == 1:
+                target_speed = current_speed if current_speed is not None else 0.0
+            else:
+                target_speed = _distance_2d(location, trajectory[min(index + 1, len(trajectory) - 1)]) / dt * 3.6
+        else:
+            target_speed = _distance_2d(previous_location, location) / dt * 3.6
+
+        if max_speed is not None:
+            target_speed = min(target_speed, max_speed)
+
+        if previous_speed is not None:
+            target_speed = _limit_speed_delta(
+                target_speed=target_speed,
+                previous_speed=previous_speed,
+                dt=dt,
+                max_accel=max_accel,
+                max_decel=max_decel,
+            )
+
+        speeds.append(target_speed)
+        previous_location = location
+        previous_speed = target_speed
+
+    return speeds
+
+
+def _distance_2d(first: Location | carla.Location, second: Location | carla.Location) -> float:
+    dx = second.x - first.x
+    dy = second.y - first.y
+    return (dx * dx + dy * dy) ** 0.5
+
+
+def _limit_speed_delta(
+    target_speed: float,
+    previous_speed: float,
+    dt: float,
+    max_accel: float | None,
+    max_decel: float | None,
+) -> float:
+    target_speed_mps = target_speed / 3.6
+    previous_speed_mps = previous_speed / 3.6
+
+    if max_accel is not None:
+        target_speed_mps = min(target_speed_mps, previous_speed_mps + max_accel * dt)
+    if max_decel is not None:
+        target_speed_mps = max(target_speed_mps, previous_speed_mps - abs(max_decel) * dt)
+
+    return max(0.0, target_speed_mps * 3.6)
+
+
+def draw_trajetory_points(
+    world: carla.World,
+    locations: Sequence[Location],
+    color: carla.Color = carla.Color(255, 0, 0),
+    life_time: float = 5,
+    size: float = 0.1,
+    _map: carla.Map = None,
+) -> None:
+    for location in locations:
+        loc = carla.Location(location.x, location.y, location.z)
+        world.debug.draw_point(loc, size=size, color=color, life_time=life_time)

--- a/opencda/core/application/behavior/services/aim_server/aim_model_manager.py
+++ b/opencda/core/application/behavior/services/aim_server/aim_model_manager.py
@@ -4,13 +4,12 @@ from typing import Any
 
 import logging
 import numpy as np
-from scipy.spatial import distance
 
 from AIM import AIMModel
 
 from .messages import AIMServerRequest, AIMServerResponse
 from .types import CavData
-from opencda.core.application.behavior.types import Transform, Location, Rotation
+from opencda.core.application.behavior.types import Transform, Location
 from . import utils
 
 from opencda.core.application.behavior.transport_message import TransportMessage
@@ -25,6 +24,7 @@ class AIMModelManager:
         control_center: Transform,
         service_name: str,
         owner_id: str,
+        control_radius: int = 15,
     ):
         """
         Initialize the standalone AIM model manager.
@@ -40,16 +40,15 @@ class AIMModelManager:
         owner_id : str
             Identifier for the owner of the AIM model.
         """
-        self.CONTROL_RADIUS = 50
-        self.THRESHOLD = 10
-        self.FORCE_VALUE = 20
+        self.CONTROL_RADIUS = control_radius
 
         self.cav_data: dict[str, CavData] = {}
+        self.cav_state: dict[str, dict] = {}
 
         self.trajs: dict[str, list[tuple[float, float, float, float, float, str]]] = {}
 
-        control_center_location = utils.get_sumo_transform(control_center, Location(0, 0, 0)).location
-
+        self.control_center_coords_carla: Transform = control_center
+        control_center_location: Location = utils.get_sumo_transform(control_center, Location(0, 0, 0)).location
         self.control_center_coords: np.ndarray = np.array([control_center_location.x, control_center_location.y])
 
         self.model = model
@@ -59,7 +58,6 @@ class AIMModelManager:
 
         self.__yaw_dict_path = Path(__file__).parent / "assets" / "yaw_dict_10m.pkl"
         self.yaw_dict: dict[str, Any] = utils.load_yaw(self.__yaw_dict_path)
-        self.yaw_id: dict[str, dict[str, str]] = {}
 
     def _get_distance_to_center(self, curr_pos: np.ndarray) -> float:
         return float(np.linalg.norm(curr_pos - self.control_center_coords))
@@ -76,10 +74,11 @@ class AIMModelManager:
         cav_pos = utils.get_sumo_transform(message.position, Location(0, 0, 0)).location
         curr_pos = np.array([cav_pos.x, cav_pos.y])
         distance_to_center = self._get_distance_to_center(curr_pos)
+        vehicle_id = message.vehicle_id
 
         if distance_to_center != -1 and distance_to_center < self.CONTROL_RADIUS:
-            self.cav_data[message.vehicle_id] = CavData(
-                intention=self.get_opencda_intention(message.waypoints, self.control_center_coords),
+            self.cav_data[vehicle_id] = CavData(
+                intention=self.get_intention(vehicle_id, message.waypoints, self.control_center_coords_carla),
                 pos=message.position.location,
                 sumo_pos=curr_pos,
                 speed=message.speed,
@@ -90,6 +89,12 @@ class AIMModelManager:
                 dst_owner_id=transport_message.dst_owner_id,
                 dst_service_type=transport_message.dst_service_type,
             )
+            if vehicle_id not in self.cav_state:
+                self.cav_state[vehicle_id] = {}
+            self.cav_state[vehicle_id]["ttl"] = 3
+        else:
+            if vehicle_id in self.cav_state:
+                del self.cav_state[vehicle_id]
 
     def _get_cav_pos(self, vehicle_id: str) -> Location:
         return self.cav_data[vehicle_id].pos
@@ -104,6 +109,11 @@ class AIMModelManager:
         """
         Run AIM inference for the request batch and return predicted targets.
         """
+        for vehicle_id in self.cav_state:
+            self.cav_state[vehicle_id]["ttl"] -= 1
+            if self.cav_state[vehicle_id]["ttl"] == 0:
+                del self.cav_state[vehicle_id]
+
         for message in messages:
             self._preprocess_cav_data(message)
         result_messages: list[TransportMessage[AIMServerResponse]] = []
@@ -123,37 +133,14 @@ class AIMModelManager:
             vehicle_id = target_agent_ids[idx]
 
             distance_to_center = self._get_distance_to_center_by_vid(vehicle_id)
-            if distance_to_center == -1:
-                continue
 
             if distance_to_center < self.CONTROL_RADIUS:
                 pred_delta = predictions[idx].reshape(30, 2).detach().cpu().numpy()
-                local_delta = pred_delta[0].reshape(2, 1)
-                last_delta = pred_delta[-1].reshape(2, 1)
+                yaw_rad = features[idx][3] - np.deg2rad(90)  # convert to carla yaw
 
-                if last_delta[1, 0] <= 1:
-                    local_delta[1, 0] = 1e-8
-                    local_delta[0, 0] = 1e-10
-                else:
-                    local_delta[1, 0] = max(1e-8, local_delta[1, 0])
-
-                yaw = features[idx][3]
-                rotation = utils.rotation_matrix_back(yaw)
-                global_delta = (rotation @ local_delta).squeeze()
-                global_delta[1] *= -1
-
-                pos = self._get_cav_pos(vehicle_id)
-
-                global_delta = np.where(np.abs(global_delta) <= self.THRESHOLD, np.sign(global_delta) * self.FORCE_VALUE, global_delta)
-
-                next_location = Location(
-                    x=pos.x + global_delta[0],
-                    y=pos.y - global_delta[1],
-                    z=pos.z,
-                )
-
+                trajectory = [self.predition_to_location(vehicle_id, pred_delta[i], yaw_rad) for i in range(30)]
                 payload = AIMServerResponse(
-                    next_position=next_location,
+                    trajectory=trajectory,
                 )
                 result_messages.append(
                     TransportMessage(
@@ -168,17 +155,20 @@ class AIMModelManager:
         self.cav_data.clear()
         return result_messages
 
+    def predition_to_location(self, vehicle_id: str, local_delta: np.ndarray, yaw: float) -> Location:
+        rotation = utils.rotation_matrix_back(yaw)
+        global_delta = (rotation @ local_delta).squeeze()
+        position = self._get_cav_pos(vehicle_id)
+
+        return Location(
+            x=position.x + global_delta[0],
+            y=position.y + global_delta[1],
+            z=position.z,
+        )
+
     def update_trajs(self) -> None:
         """
         Updates the self.trajs dictionary, which stores the trajectory history of each vehicle.
-        Format:
-        {
-            'vehicle_id': [
-                (rel_x, rel_y, speed, yaw_rad, yaw, intention),
-                ...
-            ],
-            ...
-        }
         """
         for vehicle_id in self.cav_data:
             position = self._get_cav_sumo_pos(vehicle_id)
@@ -190,20 +180,20 @@ class AIMModelManager:
                 if vehicle_id not in self.trajs:
                     self.trajs[vehicle_id] = []
 
+                if self.trajs[vehicle_id] == [] or self.trajs[vehicle_id][-1][-1] == "null":
+                    intention = self._get_cav_intention(vehicle_id)
+                else:
+                    intention = self.trajs[vehicle_id][-1][-1]
+
                 # Get vehicle state
                 speed = self.cav_data[vehicle_id].speed
                 yaw = self.cav_data[vehicle_id].yaw
-                yaw_rad = np.deg2rad(self.get_yaw(vehicle_id, position, self.yaw_dict))
+                yaw_rad = np.deg2rad(self.get_yaw(vehicle_id, position, self.yaw_dict, intention))
 
                 # Normalize position relative to control node
                 node_x, node_y = self.control_center_coords
                 rel_x = position[0] - node_x
                 rel_y = position[1] - node_y
-
-                if not self.trajs[vehicle_id] or self.trajs[vehicle_id][-1][-1] == "null":
-                    intention = self._get_cav_intention(vehicle_id)
-                else:
-                    intention = self.trajs[vehicle_id][-1][-1]
 
                 self.trajs[vehicle_id] = [(rel_x, rel_y, speed, yaw_rad, yaw, intention)]
 
@@ -211,7 +201,13 @@ class AIMModelManager:
             if vehicle_id not in self.cav_data:
                 del self.trajs[vehicle_id]
 
-    def get_opencda_intention(self, waypoints: Sequence[Any], mid: np.ndarray) -> str:
+    def get_intention(self, vehicle_id: str, waypoints: Sequence[Any], mid: Transform) -> str:
+        if vehicle_id not in self.trajs or self.trajs[vehicle_id] == [] or self.trajs[vehicle_id][-1][-1] == "null":
+            return self.get_opencda_intention(waypoints, mid)
+        else:
+            return self.trajs[vehicle_id][-1][-1]
+
+    def get_opencda_intention(self, waypoints: Sequence[Any], mid: Transform) -> str:
         """
         Gets intention by averaged rotation to pass 3 next waypoints.
 
@@ -222,18 +218,15 @@ class AIMModelManager:
         """
         # Too few waypoints
         if len(waypoints) < 2:
+            logger.debug("Too few waypoints")
             return "null"
 
         waypoint_index = 0
-        location = Location(mid[0], mid[1], 0)
-        rotation = Rotation(0, 0, 0)
 
-        in_sumo_transform = Transform(location, rotation)
-        mid_carla = utils.get_carla_transform(in_sumo_transform, Location(0, 0, 0))
-        if utils.get_distance(mid_carla, waypoints[0]) > self.CONTROL_RADIUS:
-            logger.debug("Car not int radius")
+        if utils.get_distance(mid, waypoints[0]) > self.CONTROL_RADIUS:
+            logger.debug("Car not in radius")
             return "null"
-        while utils.get_distance(mid_carla, waypoints[waypoint_index]) > self.CONTROL_RADIUS:
+        while utils.get_distance(mid, waypoints[waypoint_index]) > self.CONTROL_RADIUS:
             waypoint_index += 1
             if waypoint_index >= len(waypoints):
                 logger.debug("No waypoints in radius")
@@ -241,12 +234,13 @@ class AIMModelManager:
 
         first_waypoint = waypoints[waypoint_index]
         first_waypoint_index = waypoint_index
-        while (utils.get_distance(mid_carla, waypoints[waypoint_index]) <= self.CONTROL_RADIUS) and waypoint_index < len(waypoints) - 1:
+        while (utils.get_distance(mid, waypoints[waypoint_index]) <= self.CONTROL_RADIUS) and waypoint_index < len(waypoints) - 1:
             waypoint_index += 1
 
         # average the values of several points to reduce noise
         mean_yaw = 0
-        if waypoint_index - first_waypoint_index < 3 and waypoint_index > 3:
+        waypoints_in_radius = waypoint_index - first_waypoint_index
+        if waypoints_in_radius < 3 and waypoint_index > 3:
             logger.warning("Too few waypoints in radius")
         else:
             for i in range(3):
@@ -280,54 +274,40 @@ class AIMModelManager:
         feature_matrix = np.vstack(features) if features else np.empty((0, 7))
         return feature_matrix, target_agent_ids
 
-    def get_yaw(self, vehicle_id: str, pos: np.ndarray, yaw_dict: dict[str, Any]) -> float:
+    def get_yaw(self, vehicle_id: str, position: np.ndarray, yaw_dict: dict[str, Any], intention: str) -> float:
         """
         Calculates optimal CAV yaw based on its position, using previously collected trajectory data.
 
         :param vehicle_id: vehicle identifier
-        :param pos: 2D-position on simulation map
+        :param position: 2D-position on simulation map
         :param yaw_dict: dictionary containing information about rotation at each stage of the turn
         :return: yaw (rotation angle)
         """
-        nearest_node = "rsu"
-        if not self.trajs[vehicle_id] or self.trajs[vehicle_id][-1][-1] == "null":
-            logging.warning(f"Intention isn't defined for car {vehicle_id}")
+        if intention == "null":
+            logger.warning(f"Intention isn't defined for car {vehicle_id}")
             return 0.0
-        else:
-            intention = self.trajs[vehicle_id][-1][-1]
 
-        diff = self.control_center_coords - pos
-        if abs(diff[0]) > abs(diff[1]):
-            if diff[0] < 0:
-                start = "right"
+        if "route" not in self.cav_state[vehicle_id] or self.cav_state[vehicle_id]["route"] == "":
+            diff = self.control_center_coords - position
+            if abs(diff[0]) > abs(diff[1]):
+                if diff[0] < 0:
+                    start = "right"
+                else:
+                    start = "left"
             else:
-                start = "left"
+                if diff[1] < 0:
+                    start = "up"
+                else:
+                    start = "down"
+            end = utils.get_end(start, intention)
+            route = f"{start}_{end}"
+            self.cav_state[vehicle_id]["route"] = route
         else:
-            if diff[1] < 0:
-                start = "up"
-            else:
-                start = "down"
-
-        end = utils.get_end(start, intention)
-        v = f"{start}_{end}"
-        if vehicle_id not in self.yaw_id:
-            self.yaw_id[vehicle_id] = {nearest_node: v}
-        else:
-            if nearest_node not in self.yaw_id[vehicle_id]:
-                # With new nearest node intantion may changes, so we reset trajectory to default and get intention for new node
-                intention = self._get_cav_intention(vehicle_id)
-                end = utils.get_end(start, intention)
-                v = f"{start}_{end}"
-                self.yaw_id[vehicle_id] = {nearest_node: v}
-
-                # Update intention in trajs
-                previous_traj = self.trajs[vehicle_id][-1]
-                self.trajs[vehicle_id] = [(previous_traj[0], previous_traj[1], previous_traj[2], previous_traj[3], previous_traj[4], intention)]
-        route = self.yaw_id[vehicle_id][nearest_node]
+            route = self.cav_state[vehicle_id]["route"]
 
         if route not in yaw_dict:
-            logging.warning(f"Route '{route}' not found for vehicle {vehicle_id}. Using default yaw.")
+            logger.warning(f"Route '{route}' not found for vehicle {vehicle_id}. Using default yaw.")
             return 0.0
         yaws = yaw_dict[route]
-        dists = distance.cdist(pos.reshape(1, 2), yaws[:, :-1])
+        dists = np.linalg.norm(yaws[:, :-1] - position, axis=1)
         return float(yaws[np.argmin(dists), -1])

--- a/opencda/core/application/behavior/services/aim_server/messages.py
+++ b/opencda/core/application/behavior/services/aim_server/messages.py
@@ -24,4 +24,4 @@ class AIMServerRequest:
 class AIMServerResponse:
     """Predicted next target position for a vehicle handled by AIM."""
 
-    next_position: Location
+    trajectory: Sequence[Location]

--- a/opencda/core/application/behavior/services/movement_controller/messages.py
+++ b/opencda/core/application/behavior/services/movement_controller/messages.py
@@ -5,11 +5,12 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from opencda.core.application.behavior.types import Transform
+    from opencda.core.application.behavior.types import Location
 
 
 @dataclass(frozen=True)
 class MovementControllerRequestMessage:
     """CAV state and route context routed to the MovementController service."""
 
-    target_position: Transform
+    target_speed: float | None
+    target_location: Location | None

--- a/opencda/core/application/behavior/services/movement_controller/service.py
+++ b/opencda/core/application/behavior/services/movement_controller/service.py
@@ -64,10 +64,7 @@ class MovementController:
         valid_messages = self._filter_messages(messages)
 
         if len(valid_messages) > 0:
-            next_pos = [
-                message.target_position.location for message in valid_messages
-            ]  # TODO: think what to do if multiple messages with different target positions are received - for now we just take the first one
-
-            current_location = owner.vehicle.get_location()
-            owner.set_destination(current_location, next_pos[0], clean=True, end_reset=False)
+            # TODO: think what to do if multiple messages with different target positions are received - for now we just take the last one
+            request = valid_messages[-1]
+            owner.control(target_speed=request.target_speed, target_location=request.target_location)
         return ()

--- a/opencda/core/common/vehicle_manager.py
+++ b/opencda/core/common/vehicle_manager.py
@@ -5,7 +5,7 @@ Basic class of CAV
 from __future__ import annotations
 
 import logging
-from typing import Any, Dict, Iterable, Optional, Tuple
+from typing import Any, Iterable, Optional, Sequence, Tuple, Mapping
 import carla
 
 from opencda.core.actuation.control_manager import ControlManager
@@ -19,6 +19,7 @@ from opencda.core.plan.behavior_agent import BehaviorAgent
 from opencda.core.map.map_manager import MapManager
 from opencda.core.common.data_dumper import DataDumper
 from opencda.core.application.behavior.types import Location
+from opencda.core.application.behavior.services.movement_controller.messages import MovementControllerRequestMessage
 
 logger = logging.getLogger("cavise.opencda.opencda.core.common.vehicle_manager")
 
@@ -75,20 +76,20 @@ class VehicleManager(object):
     current_cav_id = 1
     current_platoon_id = 1
     current_unknown_id = 1
-    used_ids = set()
+    used_ids: set[str] = set()
 
     # TODO: application и prefix как будто бы дублируют друг друга, но не факт
     def __init__(
         self,
-        vehicle,
-        config_yaml,
-        application,
-        carla_map,
-        cav_world,
-        current_time="",
+        vehicle: carla.Vehicle,
+        config_yaml: Mapping[str, Any],
+        application: Sequence[str],
+        carla_map: carla.Map,
+        cav_world: carla.World,
+        current_time: str = "",
         perception_requirements: PerceptionRequirements | None = None,
-        autogenerate_id_on_failure=True,  # TODO: Link with scenario config
-        prefix="unknown",
+        autogenerate_id_on_failure: bool = True,  # TODO: Link with scenario config
+        prefix: str = "unknown",
     ):
         config_id = config_yaml.get("id")
         self.prefix = prefix if prefix in {"cav", "platoon"} else "unknown"
@@ -167,7 +168,7 @@ class VehicleManager(object):
         self.controller = ControlManager(control_config)
 
         if self.perception_requirements.enable_data_dump:
-            self.data_dumper = DataDumper(self.perception_manager, self.id, save_time=current_time)
+            self.data_dumper: DataDumper | None = DataDumper(self.perception_manager, self.id, save_time=current_time)
         else:
             self.data_dumper = None
 
@@ -178,7 +179,7 @@ class VehicleManager(object):
 
         cav_world.update_vehicle_manager(self)
 
-    def __generate_unique_vehicle_id(self):
+    def __generate_unique_vehicle_id(self) -> str:
         """Generates a unique vehicle ID based on prefix."""
         while True:
             if self.prefix == "cav":
@@ -195,7 +196,7 @@ class VehicleManager(object):
                 VehicleManager.used_ids.add(candidate)
                 return candidate
 
-    def __build_behavior_services(self, config_yaml: dict[str, Any]) -> list[BehaviorService[Any, Any]]:
+    def __build_behavior_services(self, config_yaml: Mapping[str, Any]) -> list[BehaviorService[Any, Any]]:
         service_configs = config_yaml.get("behavior_services", [])
         behavior_services = []
 
@@ -295,8 +296,8 @@ class VehicleManager(object):
 
         return valid_messages
 
-    def __group_behavior_service_messages(self, messages: list[TransportMessage]) -> Dict[str, list[TransportMessage]]:
-        grouped_messages = {service.service_name: [] for service in self.behavior_services}
+    def __group_behavior_service_messages(self, messages: list[TransportMessage]) -> Mapping[str, list[TransportMessage]]:
+        grouped_messages: Mapping[str, list[TransportMessage]] = {service.service_name: [] for service in self.behavior_services}
 
         for message in messages:
             grouped_messages[message.dst_service_type].append(message)
@@ -318,7 +319,7 @@ class VehicleManager(object):
                 out_messages = [msg for msg in result_messages if getattr(msg, "dst_owner_id", None) != self.id]
                 self.behavior_service_results.extend(out_messages)
 
-    def set_destination(self, start_location: Location, end_location: Location, clean=False, end_reset=True):
+    def set_destination(self, start_location: Location, end_location: Location, clean: bool = False, end_reset: bool = True) -> None:
         """
         Set global route.
 
@@ -344,7 +345,7 @@ class VehicleManager(object):
 
         self.agent.set_destination(start_location_carla, end_location_carla, clean, end_reset)
 
-    def update_info(self):
+    def update_info(self) -> None:
         """
         Call perception and localization module to
         retrieve surrounding info an ego position.
@@ -378,20 +379,16 @@ class VehicleManager(object):
         # pass position and speed info to controller
         self.controller.update_info(ego_pos, ego_spd)
 
-    def update_info_v2x(self):  # noqa: deadcode
+    def update_info_v2x(self) -> None:  # noqa: deadcode
         # TODO: Implement
         pass
 
-    def run_step(self, target_speed=None, messages: list[TransportMessage] = []) -> list[TransportMessage]:
-        """
-        Execute one step of navigation.
-        """
-        self.update_behavior_services(messages)
-
+    def control(self, target_speed: float | None = None, target_location: Location | None = None) -> None:
         # visualize the bev map if needed
         self.map_manager.run_step()
-        target_speed, target_pos = self.agent.run_step(target_speed)
-        control = self.controller.run_step(target_speed, target_pos)
+        if target_location is None or target_speed is None:
+            target_speed, target_location = self.agent.run_step(target_speed)
+        control = self.controller.run_step(target_speed, target_location)
 
         # dump data
         if self.data_dumper:
@@ -399,9 +396,25 @@ class VehicleManager(object):
 
         self.vehicle.apply_control(control)
 
+    def run_step(self, target_speed: float | None = None, messages: list[TransportMessage] = []) -> list[TransportMessage]:
+        """
+        Execute one step of navigation.
+        """
+        payload = MovementControllerRequestMessage(target_speed=target_speed, target_location=None)
+        messages.append(
+            TransportMessage(
+                src_owner_id=self.id,
+                src_service_type="",
+                dst_owner_id=self.id,
+                dst_service_type="movement_controller",
+                payload=payload,
+            )
+        )
+        self.update_behavior_services(messages)
+
         return self.behavior_service_results
 
-    def destroy(self):
+    def destroy(self) -> None:
         """
         Destroy the actor vehicle
         """

--- a/opencda/core/plan/behavior_agent.py
+++ b/opencda/core/plan/behavior_agent.py
@@ -566,14 +566,13 @@ class BehaviorAgent(object):
         vehicle_state, _, _ = self.collision_manager(rx, ry, ryaw, self._map.get_waypoint(self._ego_pos.location), adjacent_check=True)
         return not vehicle_state
 
-    def car_following_manager(self, vehicle, distance, target_speed=None):
+    def car_following_manager(self, vehicle: carla.Vehicle, distance: float, target_speed: float | None = None) -> float:
         """
-        Module in charge of car-following behaviors when there's
-        someone in front of us.
+        Module in charge of car-following behaviors when there's someone in front of us.
 
         Parameters
         ----------
-        vehicle : carla.vehicle)
+        vehicle : carla.Vehicle
             Leading vehicle to follow.
 
         distance : float
@@ -586,9 +585,6 @@ class BehaviorAgent(object):
         -------
         target_speed : float
             The target speed for the next step.
-
-        target_loc : carla.Location
-            The target location.
         """
         if not target_speed:
             target_speed = self.max_speed - self.speed_lim_dist
@@ -731,7 +727,9 @@ class BehaviorAgent(object):
             )
         return reset_target
 
-    def run_step(self, target_speed=None, collision_detector_enabled=True, lane_change_allowed=True):
+    def run_step(
+        self, target_speed: float | None = None, collision_detector_enabled: bool = True, lane_change_allowed: bool = True
+    ) -> tuple[float, carla.Location | None]:
         """
         Execute one step of navigation
 
@@ -749,8 +747,11 @@ class BehaviorAgent(object):
 
         Returns
         -------
-        control : carla.VehicleControl
-            Vehicle control of the next step.
+        speed : float
+            Next trajectory point's target speed。
+
+        location : carla.Location
+            Next trajectory point's location.
         """
         # retrieve ego location
         ego_vehicle_loc = self._ego_pos.location

--- a/opencda/core/plan/local_planner_behavior.py
+++ b/opencda/core/plan/local_planner_behavior.py
@@ -385,8 +385,7 @@ class LocalPlanner(object):
         # use mean curvature to constrain the speed
 
         mean_k = 0.0001 if len(rk) < 2 else abs(statistics.mean(rk))
-        # v^2 <= a_lat_max / curvature, we assume 3.6 is the maximum lateral
-        # acceleration
+        # v^2 <= a_lat_max / curvature, we assume 3.6 is the maximum lateral acceleration
         target_speed = min(target_speed, np.sqrt(5.0 / (mean_k + 10e-6)) * 3.6)
 
         max_acc = 3.5
@@ -494,7 +493,15 @@ class LocalPlanner(object):
                 for i in range(max_index + 1):
                     self._trajectory_buffer.popleft()
 
-    def run_step(self, rx, ry, rk, target_speed=None, trajectory=None, following=False):
+    def run_step(
+        self,
+        rx: list[float],
+        ry: list[float],
+        rk: list[float],
+        target_speed: float | None = None,
+        trajectory: list | None = None,
+        following: bool = False,
+    ) -> tuple[float, carla.Location | None]:
         """
         Execute one step of local planning which involves
         running the longitudinal and lateral PID controllers to
@@ -507,9 +514,6 @@ class LocalPlanner(object):
 
         ry : list
             List of planned path points' y coordinates.
-
-        ryaw : list
-            List of planned path points' yaw angles.
 
         rk : list
             List of planned path points' curvatures.
@@ -528,8 +532,8 @@ class LocalPlanner(object):
         speed : float
             Next trajectory point's target speed。
 
-        waypoint : carla.waypoint
-            Next trajectory point's waypoint.
+        location : carla.Location
+            Next trajectory point's location.
 
         """
 
@@ -543,8 +547,7 @@ class LocalPlanner(object):
                 else:
                     break
 
-        # we will generate the trajectory only if it is not a following vehicle
-        # in the platooning
+        # we will generate the trajectory only if it is not a following vehicle in the platooning
         if not trajectory and len(self._trajectory_buffer) < self.trajectory_update_freq and not following:
             self._trajectory_buffer.clear()
             # if no spline points provided, return 0 and none target wpt

--- a/opencda/scenario_testing/config_yaml/aim_check.yaml
+++ b/opencda/scenario_testing/config_yaml/aim_check.yaml
@@ -109,6 +109,7 @@ scenario:
       color: [156, 255, 206]
       behavior_services:
         - type: aim_client
+          debug: true
         - type: movement_controller
 
     - name: cav2
@@ -118,6 +119,7 @@ scenario:
       color: [156, 255, 206]
       behavior_services:
         - type: aim_client
+          debug: true
         - type: movement_controller
 
     - name: cav3
@@ -127,6 +129,7 @@ scenario:
       color: [156, 255, 206]
       behavior_services:
         - type: aim_client
+          debug: true
         - type: movement_controller
 
     - name: cav4
@@ -136,4 +139,5 @@ scenario:
       color: [156, 255, 206]
       behavior_services:
         - type: aim_client
+          debug: true
         - type: movement_controller

--- a/opencda/scenario_testing/config_yaml/default.yaml
+++ b/opencda/scenario_testing/config_yaml/default.yaml
@@ -160,6 +160,8 @@ vehicle_base:
   v2x:  # communication related
     enabled: true
     communication_range: 35
+  behavior_services:
+    - type: movement_controller
 
 
 # define the background traffic control by carla

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,7 +125,6 @@ exclude = [
     "^opencda/core/common/misc\\.py$",
     "^opencda/core/common/rsu_manager\\.py$",
     "^opencda/core/common/v2x_manager\\.py$",
-    "^opencda/core/common/vehicle_manager\\.py$",
     "^opencda/core/plan(/|$)",
     "^opencda/core/safety/safety_manager\\.py$",
     "^opencda/core/safety/sensors\\.py$",

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import sys
 import types
+from pathlib import Path
 from types import ModuleType, SimpleNamespace
 from unittest.mock import Mock
 import importlib.util
@@ -31,6 +32,7 @@ def _install_stub_if_missing(name: str, module: ModuleType) -> None:
 
 behavior_services_stub = types.ModuleType("opencda.core.application.behavior.services")
 behavior_services_stub.__all__ = []
+behavior_services_stub.__path__ = [str(Path(__file__).resolve().parents[1] / "opencda/core/application/behavior/services")]
 _install_stub_if_missing("opencda.core.application.behavior.services", behavior_services_stub)
 
 
@@ -349,6 +351,7 @@ def minimal_vehicle_config():
         "v2x": {},
         "safety_manager": {},
         "platoon": {},
+        "behavior_services": [{"type": "movement_controller"}],
     }
 
 


### PR DESCRIPTION
## Summary

<!-- What does this PR change? Why is it needed? -->
Integrates AIM trajectory outputs directly into the OpenCDA movement control flow

## Related issue

<!-- Use Closes #123 only if this PR fully resolves the issue. -->

## Changes

- Update AIM server responses from a single next position to a 30-point predicted trajectory.
- Add AIM client utilities to convert predicted trajectory points into per-point target speeds with acceleration/deceleration limits.
- Route movement control through `MovementController`, allowing direct `target_speed` + `target_location` control without remapping AIM points back to waypoints.
- Add short-lived AIM vehicle state tracking for route/yaw/intention handling near the control area.
- Add optional AIM trajectory debug drawing in `aim_check`.
- Register `movement_controller` as a default behavior service.
- Clean up type hints and re-enable linting/type checks for `vehicle_manager`.

## Validation

<!-- How was this tested or validated? -->

- [x] Simulation run
- [x] Manual verification
- [ ] Not applicable

## Checklist

- [x] Linked the related issue
- [x] Kept the PR focused and reviewable
- [ ] Updated documentation if needed
- [ ] Added or updated validation steps if needed
