### PR TITLE
[AIM] Add AIM server selection and configurable control areas

### DIFF
--- a/opencda/core/application/behavior/behavior_service_protocol.py
+++ b/opencda/core/application/behavior/behavior_service_protocol.py
@@ -15,7 +15,7 @@ BehaviorServiceResponseT = TypeVar("BehaviorServiceResponseT", covariant=True)
 class BehaviorService(Protocol[BehaviorServiceRequestT, BehaviorServiceResponseT]):
     """Protocol implemented by any behavior service attached to a participant."""
 
-    service_name: str
+    service_type: str
     priority: int = 100  # Less is better
 
     @property

--- a/opencda/core/application/behavior/registry.py
+++ b/opencda/core/application/behavior/registry.py
@@ -15,7 +15,7 @@ class BehaviorServiceRegistry:
     """
     Registry for behavior service classes.
 
-    Services are keyed by ``service_name`` and registered manually
+    Services are keyed by ``service_type`` and registered manually
     or by using ``BehaviorServiceRegistry.register`` as a decorator.
     """
 
@@ -27,28 +27,28 @@ class BehaviorServiceRegistry:
         if inspect.isabstract(service_cls):
             raise ValueError(f"Cannot register abstract behavior service class '{service_cls.__name__}'.")
 
-        if (service_name := getattr(service_cls, "service_name", None)) is None:
-            raise ValueError(f"Behavior service class '{service_cls.__name__}' must define 'service_name'.")
+        if (service_type := getattr(service_cls, "service_type", None)) is None:
+            raise ValueError(f"Behavior service class '{service_cls.__name__}' must define 'service_type'.")
 
-        if service_name in cls._registry:
-            raise ValueError(f"Duplicate behavior service registration for service='{service_name}'.")
+        if service_type in cls._registry:
+            raise ValueError(f"Duplicate behavior service registration for service='{service_type}'.")
 
-        cls._registry[service_name] = service_cls
-        logger.info("Registered behavior service class '%s' as '%s'.", service_cls.__name__, service_name)
+        cls._registry[service_type] = service_cls
+        logger.info("Registered behavior service class '%s' as '%s'.", service_cls.__name__, service_type)
         return service_cls
 
     @classmethod
-    def get_service_class(cls, service_name: str) -> type[BehaviorService[Any, Any]]:
+    def get_service_class(cls, service_type: str) -> type[BehaviorService[Any, Any]]:
         """Return a behavior service class for the given service name."""
-        if service_name not in cls._registry:
+        if service_type not in cls._registry:
             available = cls.list_services()
-            raise KeyError(f"Unknown behavior service '{service_name}'. Available: {available}")
-        return cls._registry[service_name]
+            raise KeyError(f"Unknown behavior service '{service_type}'. Available: {available}")
+        return cls._registry[service_type]
 
     @classmethod
-    def create_service(cls, service_name: str, **kwargs: Any) -> BehaviorService[Any, Any]:
+    def create_service(cls, service_type: str, **kwargs: Any) -> BehaviorService[Any, Any]:
         """Instantiate a behavior service by name."""
-        service_cls = cls.get_service_class(service_name=service_name)
+        service_cls = cls.get_service_class(service_type=service_type)
         return service_cls(**kwargs)
 
     @classmethod

--- a/opencda/core/application/behavior/services/aim_client/service.py
+++ b/opencda/core/application/behavior/services/aim_client/service.py
@@ -32,7 +32,7 @@ logger = logging.getLogger("cavise.opencda.opencda.core.application.behavior.ser
 class AIMClient:
     """Behavior service that runs AIM predictions for a batch of CAV requests."""
 
-    service_name: str = "aim_client"
+    service_type: str = "aim_client"
     priority: int = 20
 
     @property
@@ -71,7 +71,7 @@ class AIMClient:
     def get_state(self) -> AIMClientState:
         owner_ref = self._get_owner()
         return AIMClientState(
-            service_name=self.service_name,
+            service_type=self.service_type,
             owner_id=owner_ref.id if owner_ref is not None else None,
             is_attached=owner_ref is not None,
             trajectory=tuple(location for location, _ in self.trajectory),
@@ -90,7 +90,7 @@ class AIMClient:
         observed_messages: list[TransportMessage[AIMServerResponse]] = []
 
         for message in messages:
-            if message.dst_owner_id == owner.id and message.dst_service_type == self.service_name:
+            if message.dst_owner_id == owner.id and message.dst_service_type == self.service_type:
                 observed_messages.append(message)
 
         return tuple(observed_messages)
@@ -104,7 +104,7 @@ class AIMClient:
         payload = MovementControllerRequestMessage(target_location=target_location, target_speed=target_speed)
         return TransportMessage(
             src_owner_id=owner.id,
-            src_service_type=self.service_name,
+            src_service_type=self.service_type,
             dst_owner_id=owner.id,
             dst_service_type="movement_controller",
             payload=payload,
@@ -150,7 +150,7 @@ class AIMClient:
         return (
             TransportMessage(
                 src_owner_id=owner.id,
-                src_service_type=self.service_name,
+                src_service_type=self.service_type,
                 dst_owner_id=dst_owner_id,
                 dst_service_type="aim_server",
                 payload=payload,
@@ -169,7 +169,6 @@ class AIMClient:
             size=0.05,
             color=carla.Color(255, 0, 0),
             life_time=0.1,
-            _map=owner.agent._map,
         )
 
     def process(

--- a/opencda/core/application/behavior/services/aim_client/service.py
+++ b/opencda/core/application/behavior/services/aim_client/service.py
@@ -18,7 +18,7 @@ from opencda.core.application.behavior.services.aim_server import AIMServerReque
 from opencda.core.application.behavior.services.movement_controller import MovementControllerRequestMessage
 from .types import AIMClientState
 
-from .utils import get_speed, draw_trajetory_points, calculate_target_speeds, distance_squared_2d, is_location_ahead
+from .utils import get_speed, draw_trajetory_points, calculate_target_speeds, distance_2d, is_location_ahead, find_server_response
 
 if TYPE_CHECKING:
     from opencda.core.application.behavior.types import Location

--- a/opencda/core/application/behavior/services/aim_client/service.py
+++ b/opencda/core/application/behavior/services/aim_client/service.py
@@ -149,7 +149,7 @@ class AIMClient:
 
         return tuple(movement_commands)
 
-    def _build_aim_server_request_message(self, dst_owner_id: str = "broadcast") -> tuple[TransportMessage[AIMServerRequest], ...]:
+    def _build_aim_server_request_messages(self, dst_owner_id: str = "broadcast") -> tuple[TransportMessage[AIMServerRequest], ...]:
         owner = self._get_owner()
         position = owner.vehicle.get_transform()
         waypoints = owner.agent.get_local_planner().get_waypoint_buffer()

--- a/opencda/core/application/behavior/services/aim_client/service.py
+++ b/opencda/core/application/behavior/services/aim_client/service.py
@@ -18,7 +18,7 @@ from opencda.core.application.behavior.services.aim_server import AIMServerReque
 from opencda.core.application.behavior.services.movement_controller import MovementControllerRequestMessage
 from .types import AIMClientState
 
-from .utils import get_speed, draw_trajetory_points, calculate_target_speeds, distance_2d, is_location_ahead, find_server_response
+from .utils import get_speed, draw_trajetory_points, calculate_target_speeds
 
 if TYPE_CHECKING:
     from opencda.core.application.behavior.types import Location
@@ -90,7 +90,11 @@ class AIMClient:
         observed_messages: list[TransportMessage[AIMServerResponse]] = []
 
         for message in messages:
-            if message.dst_owner_id == owner.id and message.dst_service_type == self.service_type:
+            if (
+                message.dst_owner_id == owner.id
+                and message.dst_service_type == self.service_type
+                and (self.server_id == "broadcast" or self.server_id == message.src_owner_id)
+            ):
                 observed_messages.append(message)
 
         return tuple(observed_messages)
@@ -112,15 +116,21 @@ class AIMClient:
 
     def _build_movement_command_messages(
         self,
-        observed_responses: Sequence[AIMServerResponse],
+        observed_responses: Sequence[TransportMessage[AIMServerResponse]],
     ) -> tuple[TransportMessage[MovementControllerRequestMessage], ...]:
         owner = self._get_owner()
         movement_commands: list[TransportMessage[MovementControllerRequestMessage]] = []
         current_location = owner.vehicle.get_location()
         current_speed = get_speed(owner.vehicle)
 
-        for response in observed_responses:
-            control_trajectory = response.trajectory[1:]  # drop first because it was calculated on previous tick
+        if len(observed_responses) > 1:
+            logger.warning(f"Received more than one aim_server messages. Amount: {len(observed_responses)}")
+
+        if len(observed_responses) > 0:
+            response = observed_responses[0]
+            if self.server_id == "broadcast":
+                self.server_id = response.src_owner_id
+            control_trajectory = response.payload.trajectory[1:]  # drop first because it was calculated on previous tick
             target_speeds = calculate_target_speeds(control_trajectory, 0.05, current_location, current_speed, 111, 2.5, 4.5)
             self.trajectory = deque(zip(control_trajectory, target_speeds))
 
@@ -130,9 +140,12 @@ class AIMClient:
             target_location, target_speed = self.trajectory.popleft()
             movement_commands.append(self._build_movement_command_message(target_location, target_speed))
 
-        if len(movement_commands) == 0 and self.trajectory:
-            target_location, target_speed = self.trajectory.popleft()
-            movement_commands.append(self._build_movement_command_message(target_location, target_speed))
+        if len(movement_commands) == 0:
+            if self.trajectory:
+                target_location, target_speed = self.trajectory.popleft()
+                movement_commands.append(self._build_movement_command_message(target_location, target_speed))
+            else:
+                self.server_id = "broadcast"
 
         return tuple(movement_commands)
 

--- a/opencda/core/application/behavior/services/aim_client/service.py
+++ b/opencda/core/application/behavior/services/aim_client/service.py
@@ -18,7 +18,7 @@ from opencda.core.application.behavior.services.aim_server import AIMServerReque
 from opencda.core.application.behavior.services.movement_controller import MovementControllerRequestMessage
 from .types import AIMClientState
 
-from .utils import get_speed, draw_trajetory_points, calculate_target_speeds
+from .utils import get_speed, draw_trajetory_points, calculate_target_speeds, distance_squared_2d, is_location_ahead
 
 if TYPE_CHECKING:
     from opencda.core.application.behavior.types import Location
@@ -50,6 +50,7 @@ class AIMClient:
         self._owner_ref: weakref.ReferenceType[VehicleManager] | None = None
         self.priority = priority
         self.trajectory: deque[tuple[Location, float]] = deque()
+        self.server_id: str = "broadcast"
         self.debug = debug
 
     def _get_owner(self) -> VehicleManager:
@@ -84,20 +85,20 @@ class AIMClient:
     def _observe_aim_responses(
         self,
         messages: Sequence[TransportMessage[AIMServerResponse]],
-    ) -> tuple[AIMServerResponse, ...]:
+    ) -> tuple[TransportMessage[AIMServerResponse], ...]:
         owner = self._get_owner()
-        observed_messages: list[AIMServerResponse] = []
+        observed_messages: list[TransportMessage[AIMServerResponse]] = []
 
         for message in messages:
             if message.dst_owner_id == owner.id and message.dst_service_type == self.service_name:
-                observed_messages.append(message.payload)
+                observed_messages.append(message)
 
         return tuple(observed_messages)
 
     def _build_movement_command_message(
         self,
-        target_location: Location,
-        target_speed: float | None,
+        target_location: Location | None,
+        target_speed: float | None = None,
     ) -> TransportMessage[MovementControllerRequestMessage]:
         owner = self._get_owner()
         payload = MovementControllerRequestMessage(target_location=target_location, target_speed=target_speed)
@@ -135,7 +136,7 @@ class AIMClient:
 
         return tuple(movement_commands)
 
-    def _build_aim_server_request_messages(self) -> tuple[TransportMessage[AIMServerRequest], ...]:
+    def _build_aim_server_request_message(self, dst_owner_id: str = "broadcast") -> tuple[TransportMessage[AIMServerRequest], ...]:
         owner = self._get_owner()
         position = owner.vehicle.get_transform()
         waypoints = owner.agent.get_local_planner().get_waypoint_buffer()
@@ -150,7 +151,7 @@ class AIMClient:
             TransportMessage(
                 src_owner_id=owner.id,
                 src_service_type=self.service_name,
-                dst_owner_id="broadcast",
+                dst_owner_id=dst_owner_id,
                 dst_service_type="aim_server",
                 payload=payload,
             ),

--- a/opencda/core/application/behavior/services/aim_client/types.py
+++ b/opencda/core/application/behavior/services/aim_client/types.py
@@ -7,7 +7,7 @@ from opencda.core.application.behavior.types import Location
 
 @dataclass(frozen=True, slots=True)
 class AIMClientState:
-    service_name: str
+    service_type: str
     owner_id: str | None
     is_attached: bool  # noqa: DC01
     trajectory: tuple[Location, ...]  # noqa: DC01

--- a/opencda/core/application/behavior/services/aim_client/utils.py
+++ b/opencda/core/application/behavior/services/aim_client/utils.py
@@ -2,6 +2,11 @@ import carla
 import math
 from collections.abc import Sequence
 from opencda.core.application.behavior.types import Location
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from opencda.core.application.behavior.transport_message import TransportMessage
+    from opencda.core.application.behavior.services.aim_server import AIMServerResponse
 
 
 def get_speed(vehicle: carla.Vehicle, meters: bool = False) -> float:
@@ -83,9 +88,9 @@ def calculate_target_speeds(
             if len(trajectory) == 1:
                 target_speed = current_speed if current_speed is not None else 0.0
             else:
-                target_speed = _distance_2d(location, trajectory[min(index + 1, len(trajectory) - 1)]) / dt * 3.6
+                target_speed = distance_2d(location, trajectory[min(index + 1, len(trajectory) - 1)]) / dt * 3.6
         else:
-            target_speed = _distance_2d(previous_location, location) / dt * 3.6
+            target_speed = distance_2d(previous_location, location) / dt * 3.6
 
         if max_speed is not None:
             target_speed = min(target_speed, max_speed)
@@ -106,16 +111,10 @@ def calculate_target_speeds(
     return speeds
 
 
-def _distance_2d(first: Location | carla.Location, second: Location | carla.Location) -> float:
+def distance_2d(first: Location | carla.Location, second: Location | carla.Location) -> float:
     dx = second.x - first.x
     dy = second.y - first.y
     return (dx * dx + dy * dy) ** 0.5
-
-
-def distance_squared_2d(first: Location | carla.Location, second: Location | carla.Location) -> float:
-    dx = second.x - first.x
-    dy = second.y - first.y
-    return dx * dx + dy * dy
 
 
 def is_location_ahead(vehicle_transform: carla.Transform, location: Location) -> bool:
@@ -145,13 +144,22 @@ def _limit_speed_delta(
     return max(0.0, target_speed_mps * 3.6)
 
 
+def find_server_response(
+    messages: Sequence[TransportMessage[AIMServerResponse]],
+    server_id: str,
+) -> TransportMessage[AIMServerResponse] | None:
+    for message in messages:
+        if message.src_owner_id == server_id:
+            return message
+    return None
+
+
 def draw_trajetory_points(
     world: carla.World,
     locations: Sequence[Location],
     color: carla.Color = carla.Color(255, 0, 0),
     life_time: float = 5,
     size: float = 0.1,
-    _map: carla.Map = None,
 ) -> None:
     for location in locations:
         loc = carla.Location(location.x, location.y, location.z)

--- a/opencda/core/application/behavior/services/aim_client/utils.py
+++ b/opencda/core/application/behavior/services/aim_client/utils.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import carla
 import math
 from collections.abc import Sequence

--- a/opencda/core/application/behavior/services/aim_client/utils.py
+++ b/opencda/core/application/behavior/services/aim_client/utils.py
@@ -3,11 +3,6 @@ import carla
 import math
 from collections.abc import Sequence
 from opencda.core.application.behavior.types import Location
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from opencda.core.application.behavior.transport_message import TransportMessage
-    from opencda.core.application.behavior.services.aim_server import AIMServerResponse
 
 
 def get_speed(vehicle: carla.Vehicle, meters: bool = False) -> float:
@@ -89,9 +84,9 @@ def calculate_target_speeds(
             if len(trajectory) == 1:
                 target_speed = current_speed if current_speed is not None else 0.0
             else:
-                target_speed = distance_2d(location, trajectory[min(index + 1, len(trajectory) - 1)]) / dt * 3.6
+                target_speed = _distance_2d(location, trajectory[min(index + 1, len(trajectory) - 1)]) / dt * 3.6
         else:
-            target_speed = distance_2d(previous_location, location) / dt * 3.6
+            target_speed = _distance_2d(previous_location, location) / dt * 3.6
 
         if max_speed is not None:
             target_speed = min(target_speed, max_speed)
@@ -112,19 +107,10 @@ def calculate_target_speeds(
     return speeds
 
 
-def distance_2d(first: Location | carla.Location, second: Location | carla.Location) -> float:
+def _distance_2d(first: Location | carla.Location, second: Location | carla.Location) -> float:
     dx = second.x - first.x
     dy = second.y - first.y
     return (dx * dx + dy * dy) ** 0.5
-
-
-def is_location_ahead(vehicle_transform: carla.Transform, location: Location) -> bool:
-    forward_vector = vehicle_transform.get_forward_vector()
-    vehicle_location = vehicle_transform.location
-
-    dx = location.x - vehicle_location.x
-    dy = location.y - vehicle_location.y
-    return dx * forward_vector.x + dy * forward_vector.y > 0
 
 
 def _limit_speed_delta(
@@ -143,16 +129,6 @@ def _limit_speed_delta(
         target_speed_mps = max(target_speed_mps, previous_speed_mps - abs(max_decel) * dt)
 
     return max(0.0, target_speed_mps * 3.6)
-
-
-def find_server_response(
-    messages: Sequence[TransportMessage[AIMServerResponse]],
-    server_id: str,
-) -> TransportMessage[AIMServerResponse] | None:
-    for message in messages:
-        if message.src_owner_id == server_id:
-            return message
-    return None
 
 
 def draw_trajetory_points(

--- a/opencda/core/application/behavior/services/aim_client/utils.py
+++ b/opencda/core/application/behavior/services/aim_client/utils.py
@@ -112,6 +112,21 @@ def _distance_2d(first: Location | carla.Location, second: Location | carla.Loca
     return (dx * dx + dy * dy) ** 0.5
 
 
+def distance_squared_2d(first: Location | carla.Location, second: Location | carla.Location) -> float:
+    dx = second.x - first.x
+    dy = second.y - first.y
+    return dx * dx + dy * dy
+
+
+def is_location_ahead(vehicle_transform: carla.Transform, location: Location) -> bool:
+    forward_vector = vehicle_transform.get_forward_vector()
+    vehicle_location = vehicle_transform.location
+
+    dx = location.x - vehicle_location.x
+    dy = location.y - vehicle_location.y
+    return dx * forward_vector.x + dy * forward_vector.y > 0
+
+
 def _limit_speed_delta(
     target_speed: float,
     previous_speed: float,

--- a/opencda/core/application/behavior/services/aim_server/aim_model_manager.py
+++ b/opencda/core/application/behavior/services/aim_server/aim_model_manager.py
@@ -168,7 +168,6 @@ class AIMModelManager:
                 trajectory = [self.predition_to_location(vehicle_id, pred_delta[i], yaw_rad) for i in range(30)]
                 payload = AIMServerResponse(
                     trajectory=trajectory,
-                    control_center=self.control_center_carla_location,
                 )
                 result_messages.append(
                     TransportMessage(

--- a/opencda/core/application/behavior/services/aim_server/aim_model_manager.py
+++ b/opencda/core/application/behavior/services/aim_server/aim_model_manager.py
@@ -9,7 +9,7 @@ from AIM import AIMModel
 
 from .messages import AIMServerRequest, AIMServerResponse
 from .types import AIMServerState, CavData
-from opencda.core.application.behavior.types import Transform, Location
+from opencda.core.application.behavior.types import Location
 from . import utils
 
 from opencda.core.application.behavior.transport_message import TransportMessage
@@ -21,7 +21,7 @@ class AIMModelManager:
     def __init__(
         self,
         model: AIMModel,
-        control_center: Transform,
+        control_center: Location,
         service_name: str,
         owner_id: str,
         control_radius: int = 15,
@@ -47,8 +47,8 @@ class AIMModelManager:
 
         self.trajs: dict[str, list[tuple[float, float, float, float, float, str]]] = {}
 
-        self.control_center_coords_carla: Transform = control_center
-        control_center_location: Location = utils.get_sumo_transform(control_center, Location(0, 0, 0)).location
+        self.control_center_carla_location: Location = control_center
+        control_center_location: Location = utils.get_sumo_location(control_center)
         self.control_center_coords: np.ndarray = np.array([control_center_location.x, control_center_location.y])
 
         self.model = model
@@ -79,7 +79,7 @@ class AIMModelManager:
 
         if distance_to_center != -1 and distance_to_center < self.CONTROL_RADIUS:
             self.cav_data[vehicle_id] = CavData(
-                intention=self.get_intention(vehicle_id, message.waypoints, self.control_center_coords_carla),
+                intention=self.get_intention(vehicle_id, message.waypoints, self.control_center_carla_location),
                 pos=message.position.location,
                 sumo_pos=curr_pos,
                 speed=message.speed,
@@ -228,13 +228,13 @@ class AIMModelManager:
             if vehicle_id not in self.cav_data:
                 del self.trajs[vehicle_id]
 
-    def get_intention(self, vehicle_id: str, waypoints: Sequence[Any], mid: Transform) -> str:
+    def get_intention(self, vehicle_id: str, waypoints: Sequence[Any], mid: Location) -> str:
         if vehicle_id not in self.trajs or self.trajs[vehicle_id] == [] or self.trajs[vehicle_id][-1][-1] == "null":
             return self.get_opencda_intention(waypoints, mid)
         else:
             return self.trajs[vehicle_id][-1][-1]
 
-    def get_opencda_intention(self, waypoints: Sequence[Any], mid: Transform) -> str:
+    def get_opencda_intention(self, waypoints: Sequence[Any], mid: Location) -> str:
         """
         Gets intention by averaged rotation to pass 3 next waypoints.
 
@@ -250,10 +250,10 @@ class AIMModelManager:
 
         waypoint_index = 0
 
-        if utils.get_distance(mid, waypoints[0]) > self.CONTROL_RADIUS:
+        if utils.get_distance(mid, waypoints[0][0].transform.location) > self.CONTROL_RADIUS:
             logger.debug("Car not in radius")
             return "null"
-        while utils.get_distance(mid, waypoints[waypoint_index]) > self.CONTROL_RADIUS:
+        while utils.get_distance(mid, waypoints[waypoint_index][0].transform.location) > self.CONTROL_RADIUS:
             waypoint_index += 1
             if waypoint_index >= len(waypoints):
                 logger.debug("No waypoints in radius")
@@ -261,7 +261,7 @@ class AIMModelManager:
 
         first_waypoint = waypoints[waypoint_index]
         first_waypoint_index = waypoint_index
-        while (utils.get_distance(mid, waypoints[waypoint_index]) <= self.CONTROL_RADIUS) and waypoint_index < len(waypoints) - 1:
+        while utils.get_distance(mid, waypoints[waypoint_index][0].transform.location) <= self.CONTROL_RADIUS and waypoint_index < len(waypoints) - 1:
             waypoint_index += 1
 
         # average the values of several points to reduce noise

--- a/opencda/core/application/behavior/services/aim_server/aim_model_manager.py
+++ b/opencda/core/application/behavior/services/aim_server/aim_model_manager.py
@@ -168,6 +168,7 @@ class AIMModelManager:
                 trajectory = [self.predition_to_location(vehicle_id, pred_delta[i], yaw_rad) for i in range(30)]
                 payload = AIMServerResponse(
                     trajectory=trajectory,
+                    control_center=self.control_center_carla_location,
                 )
                 result_messages.append(
                     TransportMessage(

--- a/opencda/core/application/behavior/services/aim_server/aim_model_manager.py
+++ b/opencda/core/application/behavior/services/aim_server/aim_model_manager.py
@@ -22,7 +22,7 @@ class AIMModelManager:
         self,
         model: AIMModel,
         control_center: Location,
-        service_name: str,
+        service_type: str,
         owner_id: str,
         control_radius: int = 15,
     ):
@@ -35,7 +35,7 @@ class AIMModelManager:
             Loaded AIM model used for trajectory prediction.
         control_center : Transform
             Intersection control point used to normalize vehicle positions.
-        service_name : str
+        service_type : str
             Service identifier used in AIM result messages.
         owner_id : str
             Identifier for the owner of the AIM model.
@@ -53,7 +53,7 @@ class AIMModelManager:
 
         self.model = model
 
-        self._service_name = service_name
+        self._service_name = service_type
         self._owner_id = owner_id
         self._last_state_snapshot: AIMServerState | None = None
 
@@ -110,7 +110,7 @@ class AIMModelManager:
         """Return an immutable snapshot of the current AIM runtime state."""
         if self._last_state_snapshot is None:
             return AIMServerState(
-                service_name=self._service_name,
+                service_type=self._service_name,
                 owner_id=self._owner_id,
                 is_attached=True,
                 tracked_vehicle_ids=(),
@@ -122,7 +122,7 @@ class AIMModelManager:
 
     def _finalize_tick_state(self) -> None:
         self._last_state_snapshot = AIMServerState(
-            service_name=self._service_name,
+            service_type=self._service_name,
             owner_id=self._owner_id,
             is_attached=True,
             tracked_vehicle_ids=tuple(sorted(self.cav_data)),

--- a/opencda/core/application/behavior/services/aim_server/messages.py
+++ b/opencda/core/application/behavior/services/aim_server/messages.py
@@ -25,4 +25,3 @@ class AIMServerResponse:
     """Predicted next target position for a vehicle handled by AIM."""
 
     trajectory: Sequence[Location]
-    control_center: Location

--- a/opencda/core/application/behavior/services/aim_server/messages.py
+++ b/opencda/core/application/behavior/services/aim_server/messages.py
@@ -25,3 +25,4 @@ class AIMServerResponse:
     """Predicted next target position for a vehicle handled by AIM."""
 
     trajectory: Sequence[Location]
+    control_center: Location

--- a/opencda/core/application/behavior/services/aim_server/service.py
+++ b/opencda/core/application/behavior/services/aim_server/service.py
@@ -15,9 +15,11 @@ from AIM import get_model
 if TYPE_CHECKING:
     from opencda.core.common.rsu_manager import RSUManager
     from .messages import AIMServerRequest, AIMServerResponse
+    from opencda.core.application.behavior.types import Location
 
 from .aim_model_manager import AIMModelManager
 from .types import AIMServerState
+from .utils import parse_location
 
 logger = logging.getLogger("cavise.opencda.opencda.core.application.behavior.services.aim_server")
 
@@ -40,6 +42,8 @@ class AIMServer:
     def __init__(
         self,
         priority: int = 20,
+        control_radius: int = 15,
+        control_center_location: Any = None,
         **aim_config: Any,
     ) -> None:
         """
@@ -54,6 +58,8 @@ class AIMServer:
         self.aim_model_manager: AIMModelManager | None = None
         self.priority = priority
 
+        self.control_radius: int = control_radius
+        self.control_center_location: Location | None = parse_location(control_center_location)
         aim_model_name = cast(str, aim_config.pop("model", "MTP"))
         self.model = get_model(aim_model_name, **aim_config)
 
@@ -73,11 +79,13 @@ class AIMServer:
         self._owner_ref = weakref.ref(owner)
 
         owner_instance = self._get_owner()
-        owner_instance.localizer.localize()
-        control_center = owner_instance.localizer.get_ego_pos()
-        if control_center is None:
-            raise RuntimeError("AIM server could not resolve the node localization control center.")
-        self.aim_model_manager = AIMModelManager(self.model, control_center, self.service_name, owner_instance.id)
+        if self.control_center_location is None:
+            owner_instance.localizer.localize()
+            control_center = owner_instance.localizer.get_ego_pos()
+            if control_center is None:
+                raise RuntimeError("AIM server could not resolve the node localization control center.")
+            self.control_center_location = control_center.location
+        self.aim_model_manager = AIMModelManager(self.model, self.control_center_location, self.service_name, owner_instance.id, self.control_radius)
 
     def on_detach(self) -> None:
         """Release service resources before the participant is destroyed."""

--- a/opencda/core/application/behavior/services/aim_server/service.py
+++ b/opencda/core/application/behavior/services/aim_server/service.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import weakref
 import logging
-from typing import Any, Sequence, cast, TYPE_CHECKING
+from typing import Any, Sequence, cast, TYPE_CHECKING, Mapping
 
 from opencda.core.application.behavior.capability import Capability, CapabilityBindings
 from opencda.core.application.behavior.registry import BehaviorServiceRegistry
@@ -43,7 +43,7 @@ class AIMServer:
         self,
         priority: int = 20,
         control_radius: int = 15,
-        control_center_location: Any = None,
+        control_center_location: Location | Mapping | Sequence | None = None,
         **aim_config: Any,
     ) -> None:
         """

--- a/opencda/core/application/behavior/services/aim_server/service.py
+++ b/opencda/core/application/behavior/services/aim_server/service.py
@@ -28,7 +28,7 @@ logger = logging.getLogger("cavise.opencda.opencda.core.application.behavior.ser
 class AIMServer:
     """Behavior service that runs AIM predictions for a batch of CAV requests."""
 
-    service_name = "aim_server"
+    service_type = "aim_server"
     priority = 20
 
     @property
@@ -85,7 +85,7 @@ class AIMServer:
             if control_center is None:
                 raise RuntimeError("AIM server could not resolve the node localization control center.")
             self.control_center_location = control_center.location
-        self.aim_model_manager = AIMModelManager(self.model, self.control_center_location, self.service_name, owner_instance.id, self.control_radius)
+        self.aim_model_manager = AIMModelManager(self.model, self.control_center_location, self.service_type, owner_instance.id, self.control_radius)
 
     def on_detach(self) -> None:
         """Release service resources before the participant is destroyed."""
@@ -95,7 +95,7 @@ class AIMServer:
     def get_state(self) -> AIMServerState | None:
         if self.aim_model_manager is None:
             return AIMServerState(
-                service_name=self.service_name,
+                service_type=self.service_type,
                 owner_id=None,
                 is_attached=False,
                 tracked_vehicle_ids=(),

--- a/opencda/core/application/behavior/services/aim_server/types.py
+++ b/opencda/core/application/behavior/services/aim_server/types.py
@@ -23,7 +23,7 @@ class CavData:
 
 @dataclass(frozen=True, slots=True)
 class AIMServerState:
-    service_name: str
+    service_type: str
     owner_id: str | None
     is_attached: bool  # noqa: DC01
     tracked_vehicle_ids: tuple[str, ...]  # noqa: DC01

--- a/opencda/core/application/behavior/services/aim_server/utils.py
+++ b/opencda/core/application/behavior/services/aim_server/utils.py
@@ -178,7 +178,7 @@ def load_yaw(yaw_dict_path: Path | None = None) -> dict[str, Any]:
         return pkl.load(f)
 
 
-def parse_location(value: Any) -> Location | None:
+def parse_location(value: Location | Mapping | Sequence | None) -> Location | None:
     """
     Parse Location from value.
     """

--- a/opencda/core/application/behavior/services/aim_server/utils.py
+++ b/opencda/core/application/behavior/services/aim_server/utils.py
@@ -2,7 +2,7 @@ import numpy as np
 import math
 import pickle as pkl
 from pathlib import Path
-from typing import Any, Sequence
+from typing import Any, Sequence, Mapping
 
 from opencda.core.application.behavior.types import Location, Rotation, Transform
 
@@ -94,7 +94,7 @@ def get_end(start: str, intention: str) -> str:
     raise ValueError(f"Unsupported start/intention combination: start={start!r}, intention={intention!r}")
 
 
-def get_distance(waypoint1: Transform, waypoint2: Sequence[Any]) -> float:
+def get_distance(waypoint1: Location, waypoint2: Location) -> float:
     """
     Calculates Euclidean distance between two waypoints
 
@@ -102,8 +102,8 @@ def get_distance(waypoint1: Transform, waypoint2: Sequence[Any]) -> float:
     :param waypoint2: waypoint 2D-coordinates
     :return: distance
     """
-    rel_x = waypoint1.location.x - waypoint2[0].transform.location.x
-    rel_y = waypoint1.location.y - waypoint2[0].transform.location.y
+    rel_x = waypoint1.x - waypoint2.x
+    rel_y = waypoint1.y - waypoint2.y
     position = np.array([rel_x, rel_y])
     return float(np.linalg.norm(position))
 
@@ -159,6 +159,13 @@ def get_sumo_transform(in_carla_transform: Transform, extent: Location) -> Trans
     return out_transform
 
 
+def get_sumo_location(in_carla_location: Location) -> Location:
+    """
+    Returns sumo location based on carla location.
+    """
+    return Location(in_carla_location.x, -in_carla_location.y, in_carla_location.z)
+
+
 def load_yaw(yaw_dict_path: Path | None = None) -> dict[str, Any]:
     """
     Loads yaw dictionary from a predefined address.
@@ -169,3 +176,20 @@ def load_yaw(yaw_dict_path: Path | None = None) -> dict[str, Any]:
         yaw_dict_path = Path(__file__).parent / "assets" / "yaw_dict_10m.pkl"
     with yaw_dict_path.open("rb") as f:
         return pkl.load(f)
+
+
+def parse_location(value: Any) -> Location | None:
+    """
+    Parse Location from value.
+    """
+    if value is None or isinstance(value, Location):
+        return value
+    if isinstance(value, Mapping):
+        return Location(
+            x=float(value.get("x", 0)),
+            y=float(value.get("y", 0)),
+            z=float(value.get("z", 0)),
+        )
+    if isinstance(value, Sequence) and not isinstance(value, str):
+        return Location(float(value[0]), float(value[1]), float(value[2]))
+    raise TypeError(f"Invalid Location config: {value!r}")

--- a/opencda/core/application/behavior/services/movement_controller/service.py
+++ b/opencda/core/application/behavior/services/movement_controller/service.py
@@ -25,7 +25,7 @@ logger = logging.getLogger("cavise.opencda.opencda.core.application.behavior.ser
 class MovementController:
     """Behavior service that runs AIM predictions for a batch of CAV requests."""
 
-    service_name = "movement_controller"
+    service_type = "movement_controller"
     priority = 100
 
     @property
@@ -58,7 +58,7 @@ class MovementController:
     def get_state(self) -> MovementControllerState:
         owner = self._get_owner()
         return MovementControllerState(
-            service_name=self.service_name,
+            service_type=self.service_type,
             owner_id=owner.id,
             is_attached=owner is not None,
             target_position=self._target_location,
@@ -73,7 +73,7 @@ class MovementController:
         owner = self._get_owner()
         valid_messages = []
         for message in messages:
-            if message.dst_owner_id == owner.id and message.src_owner_id == owner.id and message.dst_service_type == self.service_name:
+            if message.dst_owner_id == owner.id and message.src_owner_id == owner.id and message.dst_service_type == self.service_type:
                 valid_messages.append(message.payload)
         return valid_messages
 

--- a/opencda/core/application/behavior/services/movement_controller/service.py
+++ b/opencda/core/application/behavior/services/movement_controller/service.py
@@ -38,7 +38,7 @@ class MovementController:
         """
         self.priority = priority
         self._owner_ref: weakref.ReferenceType[VehicleManager] | None = None
-        self._target_position: Location | None = None
+        self._target_location: Location | None = None
 
     def _get_owner(self) -> VehicleManager:
         owner_ref = self._owner_ref
@@ -61,13 +61,13 @@ class MovementController:
             service_name=self.service_name,
             owner_id=owner.id,
             is_attached=owner is not None,
-            target_position=self._target_position,
+            target_position=self._target_location,
         )
 
     def on_detach(self) -> None:
         """Release service resources before the participant is destroyed."""
         self._owner_ref = None
-        self._target_position = None
+        self._target_location = None
 
     def _filter_messages(self, messages: Sequence[TransportMessage[MovementControllerRequestMessage]]) -> list[MovementControllerRequestMessage]:
         owner = self._get_owner()
@@ -80,11 +80,11 @@ class MovementController:
     def process(self, messages: Sequence[TransportMessage[MovementControllerRequestMessage]]) -> tuple[TransportMessage[Any], ...]:
         owner = self._get_owner()
         valid_messages = self._filter_messages(messages)
-        self._target_position = None
+        self._target_location = None
 
         if len(valid_messages) > 0:
             # TODO: think what to do if multiple messages with different target positions are received - for now we just take the last one
             request = valid_messages[-1]
-            self._target_position = request.target_location
+            self._target_location = request.target_location
             owner.control(target_speed=request.target_speed, target_location=request.target_location)
         return ()

--- a/opencda/core/application/behavior/services/movement_controller/types.py
+++ b/opencda/core/application/behavior/services/movement_controller/types.py
@@ -5,7 +5,7 @@ from opencda.core.application.behavior.types import Location
 
 @dataclass(frozen=True, slots=True)
 class MovementControllerState:
-    service_name: str
+    service_type: str
     owner_id: str | None
     is_attached: bool  # noqa: DC01
     target_position: Location | None  # noqa: DC01

--- a/opencda/core/application/behavior/types.py
+++ b/opencda/core/application/behavior/types.py
@@ -35,5 +35,5 @@ class Rotation:
 
 @dataclass(frozen=True)
 class Transform:
-    location: Location
-    rotation: Rotation
+    location: Location = Location()
+    rotation: Rotation = Rotation()

--- a/opencda/core/attack/adversary_framework/attacks/aim_client_response_sniffer/config.yaml
+++ b/opencda/core/attack/adversary_framework/attacks/aim_client_response_sniffer/config.yaml
@@ -6,19 +6,19 @@ attack:
       - source:
           kind: snapshot
           node_type: rsu
-          service_name: aim_server
+          service_type: aim_server
         verb: exists
       - source:
           kind: snapshot
           node_type: vehicle
-          service_name: aim_client
+          service_type: aim_client
         verb: exists
 
   start_trigger:
     source:
       kind: snapshot
       node_type: rsu
-      service_name: aim_server
+      service_type: aim_server
       field: tracked_vehicle_count
     verb: increased
     value: 1
@@ -27,7 +27,7 @@ attack:
     source:
       kind: snapshot
       node_type: rsu
-      service_name: aim_server
+      service_type: aim_server
       field: tracked_vehicle_count
     verb: eq
     value: 0
@@ -37,11 +37,11 @@ attack:
     source:
       kind: snapshot
       node_type: rsu
-      service_name: aim_server
+      service_type: aim_server
       field: tracked_vehicle_ids
     resolve_to:
       node_type: vehicle
-      service_name: aim_client
+      service_type: aim_client
 
   stages:
     - id: sniff_aim_client_responses

--- a/opencda/core/attack/adversary_framework/condition_evaluator.py
+++ b/opencda/core/attack/adversary_framework/condition_evaluator.py
@@ -68,13 +68,13 @@ def collect_snapshot_values(
 
     matches: list[tuple[str, Any]] = []
     for node in _iter_matching_nodes(source, snapshot):
-        if source.service_name is None:
+        if source.service_type is None:
             value = _extract_field_value(node, source.field)
             if value is not _MISSING:
                 matches.append((node.node_id, value))
             continue
 
-        service_state = node.service_states.get(source.service_name)
+        service_state = node.service_states.get(source.service_type)
         if service_state is None:
             continue
 

--- a/opencda/core/attack/adversary_framework/models/attack_spec.py
+++ b/opencda/core/attack/adversary_framework/models/attack_spec.py
@@ -13,7 +13,7 @@ class TriggerSourceSpec:
     kind: str
     node_type: str | None = None
     node_id: str | None = None
-    service_name: str | None = None
+    service_type: str | None = None
     field: str | None = None
     attack_name: str | None = None
     stage_id: str | None = None
@@ -24,7 +24,7 @@ class TriggerSourceSpec:
             kind=str(data["kind"]),
             node_type=data.get("node_type"),
             node_id=data.get("node_id"),
-            service_name=data.get("service_name"),
+            service_type=data.get("service_type"),
             field=data.get("field"),
             attack_name=data.get("attack_name"),
             stage_id=data.get("stage_id"),
@@ -91,7 +91,7 @@ class TargetSpec:
             kind=str(data["kind"]),
             source=TriggerSourceSpec.from_dict(data["source"]),
             resolve_to_node_type=str(resolve_to["node_type"]),
-            resolve_to_service_name=str(resolve_to["service_name"]),
+            resolve_to_service_name=str(resolve_to["service_type"]),
         )
 
 

--- a/opencda/core/attack/adversary_framework/utils.py
+++ b/opencda/core/attack/adversary_framework/utils.py
@@ -40,7 +40,7 @@ def get_capability_binding(
     try:
         return service.capability_bindings[capability]
     except KeyError as exc:
-        raise RuntimeError(f"Service '{service.service_name}' does not expose capability '{capability.value}'.") from exc
+        raise RuntimeError(f"Service '{service.service_type}' does not expose capability '{capability.value}'.") from exc
 
 
 def install_output_interceptor(
@@ -53,7 +53,7 @@ def install_output_interceptor(
     binding = get_capability_binding(service, capability)
     method_name = getattr(binding, "__name__", None)
     if not method_name:
-        raise RuntimeError(f"Could not resolve method name for capability '{capability.value}' on service '{service.service_name}'.")
+        raise RuntimeError(f"Could not resolve method name for capability '{capability.value}' on service '{service.service_type}'.")
 
     had_instance_override = method_name in vars(service)
     previous_attr = vars(service).get(method_name, _MISSING)

--- a/opencda/core/common/cav_world.py
+++ b/opencda/core/common/cav_world.py
@@ -117,21 +117,21 @@ class CavWorld(object):
         """
         return self._rsu_manager_dict
 
-    def resolve_behavior_service(self, node_id: str, service_name: str) -> BehaviorService[Any, Any] | None:
+    def resolve_behavior_service(self, node_id: str, service_type: str) -> BehaviorService[Any, Any] | None:
         """
         Resolve a behavior service instance by node ID and service name.
         """
         vehicle_manager = self._vehicle_manager_dict.get(node_id)
         if vehicle_manager is not None:
             for service in vehicle_manager.behavior_services:
-                if service.service_name == service_name:
+                if service.service_type == service_type:
                     return service
             return None
 
         rsu_manager = self._rsu_manager_dict.get(node_id)
         if rsu_manager is not None:
             for service in rsu_manager.behavior_services:
-                if service.service_name == service_name:
+                if service.service_type == service_type:
                     return service
 
         return None

--- a/opencda/core/common/rsu_manager.py
+++ b/opencda/core/common/rsu_manager.py
@@ -150,7 +150,7 @@ class RSUManager(object):
             if service_type is None:
                 raise ValueError("Each behavior service config must define 'type'.")
 
-            service = create_service(service_name=service_type, **service_config_dict)
+            service = create_service(service_type=service_type, **service_config_dict)
             behavior_services.append(service)
             logger.info("Attached behavior service '%s' to RSU %r.", service_type, self.id)
 
@@ -162,7 +162,7 @@ class RSUManager(object):
         self.behavior_services = tuple(sorted(services, key=lambda service: service.priority))
         self.behavior_service_results: list[TransportMessage] = []
         self.behavior_service_states: dict[str, Any] = {}
-        self._behavior_services_by_name = {service.service_name: service for service in self.behavior_services}
+        self._behavior_services_by_name = {service.service_type: service for service in self.behavior_services}
 
     def __validate_behavior_services(self, behavior_services: Tuple[BehaviorService[Any, Any], ...]) -> None:
         seen_service_names = set()
@@ -171,14 +171,14 @@ class RSUManager(object):
             if not isinstance(service, BehaviorService):
                 raise TypeError(f"Each behavior service must implement the BehaviorService protocol; got {type(service).__name__!r}.")
 
-            service_name = service.service_name
-            if service_name in seen_service_names:
-                raise ValueError(f"Duplicate behavior service ID detected: {service_name!r}.")
+            service_type = service.service_type
+            if service_type in seen_service_names:
+                raise ValueError(f"Duplicate behavior service ID detected: {service_type!r}.")
 
             if not isinstance(service.priority, int):
-                raise TypeError(f"Behavior service {service_name!r} must define an integer priority; got {type(service.priority).__name__!r}.")
+                raise TypeError(f"Behavior service {service_type!r} must define an integer priority; got {type(service.priority).__name__!r}.")
 
-            seen_service_names.add(service_name)
+            seen_service_names.add(service_type)
 
     def __attach_behavior_services(self) -> None:
         attached_services = []
@@ -194,7 +194,7 @@ class RSUManager(object):
                 except Exception:
                     logger.exception(
                         "Failed to detach behavior service %r while rolling back RSU %r attachment.",
-                        service.service_name,
+                        service.service_type,
                         self.id,
                     )
             raise
@@ -208,7 +208,7 @@ class RSUManager(object):
             except Exception as exc:
                 logger.exception(
                     "Failed to detach behavior service %r from RSU %r.",
-                    service.service_name,
+                    service.service_type,
                     self.id,
                 )
                 if first_exception is None:
@@ -224,8 +224,8 @@ class RSUManager(object):
             if not isinstance(message, TransportMessage):
                 raise TypeError(f"Each behavior service message must be a TransportMessage; got {type(message).__name__!r}.")
 
-            service_name = getattr(message, "dst_service_type", None)
-            if not isinstance(service_name, str):
+            service_type = getattr(message, "dst_service_type", None)
+            if not isinstance(service_type, str):
                 raise TypeError(f"Each behavior service message must define a string 'dst_service_type'; got {type(message).__name__!r}.")
 
             owner_id = getattr(message, "dst_owner_id", None)
@@ -233,17 +233,17 @@ class RSUManager(object):
                 raise TypeError(f"Each behavior service message must define a string 'dst_owner_id'; got {type(message).__name__!r}.")
 
             if owner_id == self.id:
-                if service_name not in self._behavior_services_by_name:
-                    raise ValueError(f"Behavior service message references unknown service_name {service_name!r}.")
+                if service_type not in self._behavior_services_by_name:
+                    raise ValueError(f"Behavior service message references unknown service_type {service_type!r}.")
                 valid_messages.append(message)
             elif owner_id == "broadcast" and message.src_owner_id != self.id:
-                if service_name in self._behavior_services_by_name:
+                if service_type in self._behavior_services_by_name:
                     valid_messages.append(message)
 
         return valid_messages
 
     def __group_behavior_service_messages(self, messages: list[TransportMessage]) -> dict[str, list[TransportMessage]]:
-        grouped_messages = {service.service_name: [] for service in self.behavior_services}
+        grouped_messages = {service.service_type: [] for service in self.behavior_services}
 
         for message in messages:
             grouped_messages[message.dst_service_type].append(message)
@@ -256,9 +256,9 @@ class RSUManager(object):
         self.behavior_service_results.clear()
 
         for service in self.behavior_services:
-            service_messages = grouped_messages[service.service_name]
+            service_messages = grouped_messages[service.service_type]
             result_messages = service.process(service_messages)
-            self.behavior_service_states[service.service_name] = service.get_state()
+            self.behavior_service_states[service.service_type] = service.get_state()
             if result_messages:
                 self_messages = [msg for msg in result_messages if getattr(msg, "dst_owner_id", None) == self.id]
                 messages.extend(self_messages)

--- a/opencda/core/common/vehicle_manager.py
+++ b/opencda/core/common/vehicle_manager.py
@@ -206,7 +206,7 @@ class VehicleManager(object):
             if service_type is None:
                 raise ValueError("Each behavior service config must define 'type'.")
 
-            behavior_services.append(create_service(service_name=service_type, **service_config_dict))
+            behavior_services.append(create_service(service_type=service_type, **service_config_dict))
             logger.info("Attached behavior service '%s' to vehicle %r.", service_type, self.id)
 
         return behavior_services
@@ -217,7 +217,7 @@ class VehicleManager(object):
         self.behavior_services = tuple(sorted(services, key=lambda service: service.priority))
         self.behavior_service_results: list[TransportMessage] = []
         self.behavior_service_states: dict[str, Any] = {}
-        self._behavior_services_by_name = {service.service_name: service for service in self.behavior_services}
+        self._behavior_services_by_name = {service.service_type: service for service in self.behavior_services}
 
     def __validate_behavior_services(self, behavior_services: Tuple[BehaviorService[Any, Any], ...]) -> None:
         seen_service_ids = set()
@@ -226,14 +226,14 @@ class VehicleManager(object):
             if not isinstance(service, BehaviorService):
                 raise TypeError(f"Each behavior service must implement the BehaviorService protocol; got {type(service).__name__!r}.")
 
-            service_name = service.service_name
-            if service_name in seen_service_ids:
-                raise ValueError(f"Duplicate behavior service ID detected: {service_name!r}.")
+            service_type = service.service_type
+            if service_type in seen_service_ids:
+                raise ValueError(f"Duplicate behavior service ID detected: {service_type!r}.")
 
             if not isinstance(service.priority, int):
-                raise TypeError(f"Behavior service {service_name!r} must define an integer priority; got {type(service.priority).__name__!r}.")
+                raise TypeError(f"Behavior service {service_type!r} must define an integer priority; got {type(service.priority).__name__!r}.")
 
-            seen_service_ids.add(service_name)
+            seen_service_ids.add(service_type)
 
     def __attach_behavior_services(self) -> None:
         attached_services = []
@@ -249,7 +249,7 @@ class VehicleManager(object):
                 except Exception:
                     logger.exception(
                         "Failed to detach behavior service %r while rolling back vehicle %r attachment.",
-                        service.service_name,
+                        service.service_type,
                         self.id,
                     )
             raise
@@ -263,7 +263,7 @@ class VehicleManager(object):
             except Exception as exc:
                 logger.exception(
                     "Failed to detach behavior service %r from vehicle %r.",
-                    service.service_name,
+                    service.service_type,
                     self.id,
                 )
                 if first_exception is None:
@@ -279,8 +279,8 @@ class VehicleManager(object):
             if not isinstance(message, TransportMessage):
                 raise TypeError(f"Each behavior service message must be a TransportMessage; got {type(message).__name__!r}.")
 
-            service_name = getattr(message, "dst_service_type", None)
-            if not isinstance(service_name, str):
+            service_type = getattr(message, "dst_service_type", None)
+            if not isinstance(service_type, str):
                 raise TypeError(f"Each behavior service message must define a string 'dst_service_type'; got {type(message).__name__!r}.")
 
             owner_id = getattr(message, "dst_owner_id", None)
@@ -288,17 +288,17 @@ class VehicleManager(object):
                 raise TypeError(f"Each behavior service message must define a string 'dst_owner_id'; got {type(message).__name__!r}.")
 
             if owner_id == self.id:
-                if service_name not in self._behavior_services_by_name:
-                    raise ValueError(f"Behavior service message references unknown service_name {service_name!r}.")
+                if service_type not in self._behavior_services_by_name:
+                    raise ValueError(f"Behavior service message references unknown service_type {service_type!r}.")
                 valid_messages.append(message)
             elif owner_id == "broadcast" and message.src_owner_id != self.id:
-                if service_name in self._behavior_services_by_name:
+                if service_type in self._behavior_services_by_name:
                     valid_messages.append(message)
 
         return valid_messages
 
     def __group_behavior_service_messages(self, messages: list[TransportMessage]) -> Mapping[str, list[TransportMessage]]:
-        grouped_messages: Mapping[str, list[TransportMessage]] = {service.service_name: [] for service in self.behavior_services}
+        grouped_messages: Mapping[str, list[TransportMessage]] = {service.service_type: [] for service in self.behavior_services}
 
         for message in messages:
             grouped_messages[message.dst_service_type].append(message)
@@ -311,9 +311,9 @@ class VehicleManager(object):
         self.behavior_service_results.clear()
 
         for service in self.behavior_services:
-            service_messages = grouped_messages[service.service_name]
+            service_messages = grouped_messages[service.service_type]
             result_messages = service.process(service_messages)
-            self.behavior_service_states[service.service_name] = service.get_state()
+            self.behavior_service_states[service.service_type] = service.get_state()
             if result_messages:
                 self_messages = [msg for msg in result_messages if getattr(msg, "dst_owner_id", None) == self.id]
                 messages.extend(self_messages)

--- a/opencda/scenario_testing/config_yaml/aim_check.yaml
+++ b/opencda/scenario_testing/config_yaml/aim_check.yaml
@@ -96,6 +96,11 @@ scenario:
       id: 1
       behavior_services:
         - type: aim_server
+          control_radius: 15
+          control_center_location:
+            x: 256
+            y: -171
+            z: 15
           model: "MTP"
           underling_model: "GNN_mtl_gnn"
           hidden_channels: 128


### PR DESCRIPTION
## Summary

<!-- What does this PR change? Why is it needed? -->
Updated the AIM client so it remembers server for future requests and made AIM server control areas configurable from YAML.

## Related issue

<!-- Use Closes #123 only if this PR fully resolves the issue. -->

## Changes

- Added YAML configuration support for AIM server `control_radius` and `control_center_location`.
- Updated AIM client server selection:
  - remember the server and send future requests directly to it.

## Validation

<!-- How was this tested or validated? -->

- [x] Simulation run
- [x] Manual verification
- [ ] Not applicable

## Checklist

- [x] Linked the related issue
- [x] Kept the PR focused and reviewable
- [x] Updated documentation if needed
- [x] Added or updated validation steps if needed
