### PR TITLE
[service] Add self-informer service for local CAV state broadcasts

### DIFF
--- a/opencda/core/application/behavior/__init__.py
+++ b/opencda/core/application/behavior/__init__.py
@@ -14,7 +14,7 @@ import importlib
 from .capability import Capability, CapabilityBinding, CapabilityBindings
 from .behavior_service_protocol import BehaviorService
 from .registry import BehaviorServiceRegistry
-from .transport_message import TransportMessage
+from .transport_message import TransportMessage, BROADCAST_OWNER_ID, BROADCAST_SERVICE_TYPE
 
 # Initialize builtin behavior service discovery.
 importlib.import_module("opencda.core.application.behavior.services")
@@ -33,4 +33,6 @@ __all__ = [
     "create_service",
     "get_service_class",
     "list_services",
+    "BROADCAST_OWNER_ID",
+    "BROADCAST_SERVICE_TYPE",
 ]

--- a/opencda/core/application/behavior/services/aim_client/service.py
+++ b/opencda/core/application/behavior/services/aim_client/service.py
@@ -13,7 +13,7 @@ import carla
 
 from opencda.core.application.behavior.capability import Capability, CapabilityBindings
 from opencda.core.application.behavior.registry import BehaviorServiceRegistry
-from opencda.core.application.behavior.transport_message import TransportMessage
+from opencda.core.application.behavior.transport_message import TransportMessage, BROADCAST_OWNER_ID, BROADCAST_SERVICE_TYPE
 from opencda.core.application.behavior.services.aim_server import AIMServerRequest, AIMServerResponse
 from opencda.core.application.behavior.services.movement_controller import MovementControllerRequestMessage
 from opencda.core.application.behavior.services.self_informer import SelfInformerResponse
@@ -51,7 +51,7 @@ class AIMClient:
         self._owner_ref: weakref.ReferenceType[VehicleManager] | None = None
         self.priority = priority
         self.trajectory: deque[tuple[Location, float]] = deque()
-        self.server_id: str = "broadcast"
+        self.server_id: str = BROADCAST_OWNER_ID
         self.debug = debug
         self._self_informer_data: SelfInformerResponse | None = None
 
@@ -96,15 +96,15 @@ class AIMClient:
             if isinstance(message.payload, AIMServerResponse):
                 if (
                     message.dst_owner_id == owner.id
-                    and message.dst_service_type in (self.service_type, "broadcast")
-                    and (self.server_id == "broadcast" or self.server_id == message.src_owner_id)
+                    and message.dst_service_type in (self.service_type, BROADCAST_SERVICE_TYPE)
+                    and (self.server_id == BROADCAST_OWNER_ID or self.server_id == message.src_owner_id)
                 ):
                     aim_server_responses.append(cast(TransportMessage[AIMServerResponse], message))
             elif isinstance(message.payload, SelfInformerResponse):
                 if (
                     message.dst_owner_id == owner.id
                     and message.src_owner_id == owner.id
-                    and message.dst_service_type in (self.service_type, "broadcast")
+                    and message.dst_service_type in (self.service_type, BROADCAST_SERVICE_TYPE)
                 ):
                     self_informer_responses.append(message.payload)
 
@@ -148,7 +148,7 @@ class AIMClient:
 
         if len(aim_server_responses) > 0:
             response = aim_server_responses[0]
-            if self.server_id == "broadcast":
+            if self.server_id == BROADCAST_OWNER_ID:
                 self.server_id = response.src_owner_id
             control_trajectory = response.payload.trajectory[1:]  # drop first because it was calculated on previous tick
             if self._self_informer_data is None:
@@ -169,11 +169,11 @@ class AIMClient:
                 target_location, target_speed = self.trajectory.popleft()
                 movement_commands.append(self._build_movement_command_message(target_location, target_speed))
             else:
-                self.server_id = "broadcast"
+                self.server_id = BROADCAST_OWNER_ID
 
         return tuple(movement_commands)
 
-    def _build_aim_server_request_messages(self, dst_owner_id: str = "broadcast") -> tuple[TransportMessage[AIMServerRequest], ...]:
+    def _build_aim_server_request_messages(self, dst_owner_id: str = BROADCAST_OWNER_ID) -> tuple[TransportMessage[AIMServerRequest], ...]:
         owner = self._get_owner()
         position = owner.vehicle.get_transform()
         waypoints = owner.agent.get_local_planner().get_waypoint_buffer()

--- a/opencda/core/application/behavior/services/aim_client/service.py
+++ b/opencda/core/application/behavior/services/aim_client/service.py
@@ -71,11 +71,10 @@ class AIMClient:
         self._owner_ref = weakref.ref(owner)
 
     def get_state(self) -> AIMClientState:
-        owner_ref = self._get_owner()
+        owner = self._get_owner()
         return AIMClientState(
             service_type=self.service_type,
-            owner_id=owner_ref.id if owner_ref is not None else None,
-            is_attached=owner_ref is not None,
+            owner_id=owner.id,
             trajectory=tuple(location for location, _ in self.trajectory),
         )
 

--- a/opencda/core/application/behavior/services/aim_client/service.py
+++ b/opencda/core/application/behavior/services/aim_client/service.py
@@ -6,7 +6,7 @@ import weakref
 import logging
 from collections import deque
 from collections.abc import Sequence
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 import traci
 import carla
@@ -16,9 +16,10 @@ from opencda.core.application.behavior.registry import BehaviorServiceRegistry
 from opencda.core.application.behavior.transport_message import TransportMessage
 from opencda.core.application.behavior.services.aim_server import AIMServerRequest, AIMServerResponse
 from opencda.core.application.behavior.services.movement_controller import MovementControllerRequestMessage
+from opencda.core.application.behavior.services.self_informer import SelfInformerResponse
 from .types import AIMClientState
 
-from .utils import get_speed, draw_trajetory_points, calculate_target_speeds
+from .utils import draw_trajetory_points, calculate_target_speeds
 
 if TYPE_CHECKING:
     from opencda.core.application.behavior.types import Location
@@ -52,6 +53,7 @@ class AIMClient:
         self.trajectory: deque[tuple[Location, float]] = deque()
         self.server_id: str = "broadcast"
         self.debug = debug
+        self._self_informer_data: SelfInformerResponse | None = None
 
     def _get_owner(self) -> VehicleManager:
         owner_ref = self._owner_ref
@@ -84,20 +86,40 @@ class AIMClient:
 
     def _observe_aim_responses(
         self,
-        messages: Sequence[TransportMessage[AIMServerResponse]],
-    ) -> tuple[TransportMessage[AIMServerResponse], ...]:
+        messages: Sequence[TransportMessage[AIMServerResponse | SelfInformerResponse]],
+    ) -> tuple[tuple[TransportMessage[AIMServerResponse], ...], tuple[SelfInformerResponse, ...]]:
         owner = self._get_owner()
-        observed_messages: list[TransportMessage[AIMServerResponse]] = []
+        aim_server_responses: list[TransportMessage[AIMServerResponse]] = []
+        self_informer_responses: list[SelfInformerResponse] = []
 
         for message in messages:
-            if (
-                message.dst_owner_id == owner.id
-                and message.dst_service_type == self.service_type
-                and (self.server_id == "broadcast" or self.server_id == message.src_owner_id)
-            ):
-                observed_messages.append(message)
+            if isinstance(message.payload, AIMServerResponse):
+                if (
+                    message.dst_owner_id == owner.id
+                    and message.dst_service_type in (self.service_type, "broadcast")
+                    and (self.server_id == "broadcast" or self.server_id == message.src_owner_id)
+                ):
+                    aim_server_responses.append(cast(TransportMessage[AIMServerResponse], message))
+            elif isinstance(message.payload, SelfInformerResponse):
+                if (
+                    message.dst_owner_id == owner.id
+                    and message.src_owner_id == owner.id
+                    and message.dst_service_type in (self.service_type, "broadcast")
+                ):
+                    self_informer_responses.append(message.payload)
 
-        return tuple(observed_messages)
+        return tuple(aim_server_responses), tuple(self_informer_responses)
+
+    def _handle_self_informer_responses(
+        self,
+        self_informer_responses: Sequence[SelfInformerResponse],
+    ) -> None:
+        if len(self_informer_responses) <= 0:
+            raise RuntimeError("No self_informer_responses received")
+        else:
+            if len(self_informer_responses) > 1:
+                logger.warning(f"Received more than one self_informer responses. Amount: {len(self_informer_responses)}")
+            self._self_informer_data = self_informer_responses[0]
 
     def _build_movement_command_message(
         self,
@@ -116,21 +138,23 @@ class AIMClient:
 
     def _build_movement_command_messages(
         self,
-        observed_responses: Sequence[TransportMessage[AIMServerResponse]],
+        aim_server_responses: Sequence[TransportMessage[AIMServerResponse]],
     ) -> tuple[TransportMessage[MovementControllerRequestMessage], ...]:
         owner = self._get_owner()
         movement_commands: list[TransportMessage[MovementControllerRequestMessage]] = []
-        current_location = owner.vehicle.get_location()
-        current_speed = get_speed(owner.vehicle)
 
-        if len(observed_responses) > 1:
-            logger.warning(f"Received more than one aim_server messages. Amount: {len(observed_responses)}")
+        if len(aim_server_responses) > 1:
+            logger.warning(f"Received more than one aim_server messages. Amount: {len(aim_server_responses)}")
 
-        if len(observed_responses) > 0:
-            response = observed_responses[0]
+        if len(aim_server_responses) > 0:
+            response = aim_server_responses[0]
             if self.server_id == "broadcast":
                 self.server_id = response.src_owner_id
             control_trajectory = response.payload.trajectory[1:]  # drop first because it was calculated on previous tick
+            if self._self_informer_data is None:
+                raise RuntimeError("_self_informer_data not set")
+            current_location = self._self_informer_data.location
+            current_speed = self._self_informer_data.speed
             target_speeds = calculate_target_speeds(control_trajectory, 0.05, current_location, current_speed, 111, 2.5, 4.5)
             self.trajectory = deque(zip(control_trajectory, target_speeds))
 
@@ -186,9 +210,10 @@ class AIMClient:
 
     def process(
         self,
-        messages: Sequence[TransportMessage[AIMServerResponse]],
+        messages: Sequence[TransportMessage[AIMServerResponse | SelfInformerResponse]],
     ) -> tuple[TransportMessage[MovementControllerRequestMessage | AIMServerRequest], ...]:
-        observed_responses = self._observe_aim_responses(messages)
-        movement_commands = self._build_movement_command_messages(observed_responses)
+        aim_server_responses, self_informer_responses = self._observe_aim_responses(messages)
+        self._handle_self_informer_responses(self_informer_responses)
+        movement_commands = self._build_movement_command_messages(aim_server_responses)
         aim_requests = self._build_aim_server_request_messages()
         return (*movement_commands, *aim_requests)

--- a/opencda/core/application/behavior/services/aim_client/types.py
+++ b/opencda/core/application/behavior/services/aim_client/types.py
@@ -9,5 +9,4 @@ from opencda.core.application.behavior.types import Location
 class AIMClientState:
     service_type: str
     owner_id: str | None
-    is_attached: bool  # noqa: DC01
     trajectory: tuple[Location, ...]  # noqa: DC01

--- a/opencda/core/application/behavior/services/aim_client/utils.py
+++ b/opencda/core/application/behavior/services/aim_client/utils.py
@@ -1,30 +1,7 @@
 from __future__ import annotations
 import carla
-import math
 from collections.abc import Sequence
 from opencda.core.application.behavior.types import Location
-
-
-def get_speed(vehicle: carla.Vehicle, meters: bool = False) -> float:
-    """
-    Compute speed of a vehicle in Km/h.
-
-    Parameters
-    ----------
-    meters : bool
-        Whether to use m/s (True) or km/h (False).
-
-    vehicle : carla.vehicle
-        The vehicle for which speed is calculated.
-
-    Returns
-    -------
-    speed : float
-        The vehicle speed.
-    """
-    vel = vehicle.get_velocity()
-    vel_meter_per_second = math.sqrt(vel.x**2 + vel.y**2 + vel.z**2)
-    return vel_meter_per_second if meters else 3.6 * vel_meter_per_second
 
 
 def calculate_target_speeds(

--- a/opencda/core/application/behavior/services/aim_server/aim_model_manager.py
+++ b/opencda/core/application/behavior/services/aim_server/aim_model_manager.py
@@ -112,7 +112,6 @@ class AIMModelManager:
             return AIMServerState(
                 service_type=self._service_name,
                 owner_id=self._owner_id,
-                is_attached=True,
                 tracked_vehicle_ids=(),
                 trajectory_vehicle_ids=(),
                 tracked_vehicle_count=0,
@@ -124,7 +123,6 @@ class AIMModelManager:
         self._last_state_snapshot = AIMServerState(
             service_type=self._service_name,
             owner_id=self._owner_id,
-            is_attached=True,
             tracked_vehicle_ids=tuple(sorted(self.cav_data)),
             trajectory_vehicle_ids=tuple(sorted(self.trajs)),
             tracked_vehicle_count=len(self.cav_data),

--- a/opencda/core/application/behavior/services/aim_server/service.py
+++ b/opencda/core/application/behavior/services/aim_server/service.py
@@ -97,7 +97,6 @@ class AIMServer:
             return AIMServerState(
                 service_type=self.service_type,
                 owner_id=None,
-                is_attached=False,
                 tracked_vehicle_ids=(),
                 trajectory_vehicle_ids=(),
                 tracked_vehicle_count=0,

--- a/opencda/core/application/behavior/services/aim_server/types.py
+++ b/opencda/core/application/behavior/services/aim_server/types.py
@@ -25,7 +25,6 @@ class CavData:
 class AIMServerState:
     service_type: str
     owner_id: str | None
-    is_attached: bool  # noqa: DC01
     tracked_vehicle_ids: tuple[str, ...]  # noqa: DC01
     trajectory_vehicle_ids: tuple[str, ...]  # noqa: DC01
     tracked_vehicle_count: int  # noqa: DC01

--- a/opencda/core/application/behavior/services/movement_controller/service.py
+++ b/opencda/core/application/behavior/services/movement_controller/service.py
@@ -16,6 +16,7 @@ from .types import MovementControllerState
 
 if TYPE_CHECKING:
     from opencda.core.common.vehicle_manager import VehicleManager
+    from opencda.core.application.behavior.services.self_informer import SelfInformerResponse
 
 
 logger = logging.getLogger("cavise.opencda.opencda.core.application.behavior.services.aim_client")
@@ -69,15 +70,24 @@ class MovementController:
         self._owner_ref = None
         self._target_location = None
 
-    def _filter_messages(self, messages: Sequence[TransportMessage[MovementControllerRequestMessage]]) -> list[MovementControllerRequestMessage]:
+    def _filter_messages(
+        self, messages: Sequence[TransportMessage[MovementControllerRequestMessage | SelfInformerResponse]]
+    ) -> list[MovementControllerRequestMessage]:
         owner = self._get_owner()
         valid_messages = []
         for message in messages:
-            if message.dst_owner_id == owner.id and message.src_owner_id == owner.id and message.dst_service_type == self.service_type:
+            if (
+                message.dst_owner_id == owner.id
+                and message.src_owner_id == owner.id
+                and message.dst_service_type in (self.service_type, "broadcast")
+                and isinstance(message.payload, MovementControllerRequestMessage)
+            ):
                 valid_messages.append(message.payload)
         return valid_messages
 
-    def process(self, messages: Sequence[TransportMessage[MovementControllerRequestMessage]]) -> tuple[TransportMessage[Any], ...]:
+    def process(
+        self, messages: Sequence[TransportMessage[MovementControllerRequestMessage | SelfInformerResponse]]
+    ) -> tuple[TransportMessage[Any], ...]:
         owner = self._get_owner()
         valid_messages = self._filter_messages(messages)
         self._target_location = None

--- a/opencda/core/application/behavior/services/movement_controller/service.py
+++ b/opencda/core/application/behavior/services/movement_controller/service.py
@@ -8,7 +8,7 @@ from typing import Any, Sequence, TYPE_CHECKING
 
 from opencda.core.application.behavior.capability import CapabilityBindings
 from opencda.core.application.behavior.registry import BehaviorServiceRegistry
-from opencda.core.application.behavior.transport_message import TransportMessage
+from opencda.core.application.behavior.transport_message import TransportMessage, BROADCAST_SERVICE_TYPE
 from opencda.core.application.behavior.types import Location
 from .messages import MovementControllerRequestMessage
 from .types import MovementControllerState
@@ -79,7 +79,7 @@ class MovementController:
             if (
                 message.dst_owner_id == owner.id
                 and message.src_owner_id == owner.id
-                and message.dst_service_type in (self.service_type, "broadcast")
+                and message.dst_service_type in (self.service_type, BROADCAST_SERVICE_TYPE)
                 and isinstance(message.payload, MovementControllerRequestMessage)
             ):
                 valid_messages.append(message.payload)

--- a/opencda/core/application/behavior/services/movement_controller/service.py
+++ b/opencda/core/application/behavior/services/movement_controller/service.py
@@ -61,7 +61,6 @@ class MovementController:
         return MovementControllerState(
             service_type=self.service_type,
             owner_id=owner.id,
-            is_attached=owner is not None,
             target_position=self._target_location,
         )
 

--- a/opencda/core/application/behavior/services/self_informer/__init__.py
+++ b/opencda/core/application/behavior/services/self_informer/__init__.py
@@ -2,8 +2,10 @@
 
 from .service import SelfInformer
 from .messages import SelfInformerResponse
+from .types import SelfInformerState
 
 __all__ = [
     "SelfInformer",
     "SelfInformerResponse",
+    "SelfInformerState",
 ]

--- a/opencda/core/application/behavior/services/self_informer/__init__.py
+++ b/opencda/core/application/behavior/services/self_informer/__init__.py
@@ -1,0 +1,9 @@
+"""Self-informer service package."""
+
+from .service import SelfInformer
+from .messages import SelfInformerResponse
+
+__all__ = [
+    "SelfInformer",
+    "SelfInformerResponse",
+]

--- a/opencda/core/application/behavior/services/self_informer/messages.py
+++ b/opencda/core/application/behavior/services/self_informer/messages.py
@@ -1,0 +1,16 @@
+"""Message dataclasses for the self-informer behavior service."""
+
+from __future__ import annotations
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from opencda.core.application.behavior.types import Location
+
+
+@dataclass(frozen=True)
+class SelfInformerResponse:
+    """Current vehicle state published by the self-informer service."""
+
+    location: Location | None
+    speed: float | None

--- a/opencda/core/application/behavior/services/self_informer/service.py
+++ b/opencda/core/application/behavior/services/self_informer/service.py
@@ -1,0 +1,84 @@
+"""Self-informer behavior service implementation."""
+
+from __future__ import annotations
+
+import weakref
+import logging
+from collections.abc import Sequence
+from typing import TYPE_CHECKING, Any
+
+from opencda.core.application.behavior.capability import Capability, CapabilityBindings
+from opencda.core.application.behavior.registry import BehaviorServiceRegistry
+from opencda.core.application.behavior.transport_message import TransportMessage
+from .messages import SelfInformerResponse
+from .utils import get_speed
+from opencda.core.application.behavior.types import Location
+
+if TYPE_CHECKING:
+    from opencda.core.common.vehicle_manager import VehicleManager
+
+
+logger = logging.getLogger("cavise.opencda.opencda.core.application.behavior.services.self_informer")
+
+
+@BehaviorServiceRegistry.register
+class SelfInformer:
+    """Behavior service that publishes the owner's current CAV state."""
+
+    service_type: str = "self_informer"
+    priority: int = 1
+
+    @property
+    def capability_bindings(self) -> CapabilityBindings:
+        return {
+            Capability.REQUEST_SUBMIT: self._build_self_informer_response,
+        }
+
+    def __init__(self, priority: int = 1) -> None:
+        """Initialize the self-informer behavior service."""
+        self._owner_ref: weakref.ReferenceType[VehicleManager] | None = None
+        self.priority = priority
+
+    def _get_owner(self) -> VehicleManager:
+        owner_ref = self._owner_ref
+        if owner_ref is None:
+            raise RuntimeError("Self-informer is not attached to an owner.")
+
+        owner = owner_ref()
+        if owner is None:
+            raise RuntimeError("Self-informer owner is no longer available.")
+
+        return owner
+
+    def on_attach(self, owner: VehicleManager) -> None:
+        """Initialize the service for a particular participant instance."""
+        self._owner_ref = weakref.ref(owner)
+
+    def on_detach(self) -> None:
+        """Release service resources before the participant is destroyed."""
+        self._owner_ref = None
+
+    def get_state(self) -> Any:
+        """Return an immutable snapshot of the current service state."""
+        pass
+
+    def _build_self_informer_response(
+        self,
+    ) -> TransportMessage[SelfInformerResponse]:
+        owner = self._get_owner()
+        current_location = Location.from_carla(owner.vehicle.get_location())
+        current_speed = get_speed(owner.vehicle)
+        payload = SelfInformerResponse(location=current_location, speed=current_speed)
+        return TransportMessage(
+            src_owner_id=owner.id,
+            src_service_type=self.service_type,
+            dst_owner_id=owner.id,
+            dst_service_type="broadcast",
+            payload=payload,
+        )
+
+    def process(
+        self,
+        messages: Sequence[TransportMessage[Any]],
+    ) -> tuple[TransportMessage[SelfInformerResponse], ...]:
+        return (self._build_self_informer_response(),)

--- a/opencda/core/application/behavior/services/self_informer/service.py
+++ b/opencda/core/application/behavior/services/self_informer/service.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, Any
 
 from opencda.core.application.behavior.capability import Capability, CapabilityBindings
 from opencda.core.application.behavior.registry import BehaviorServiceRegistry
-from opencda.core.application.behavior.transport_message import TransportMessage
+from opencda.core.application.behavior.transport_message import TransportMessage, BROADCAST_SERVICE_TYPE
 from .messages import SelfInformerResponse
 from .utils import get_speed
 from opencda.core.application.behavior.types import Location
@@ -73,7 +73,7 @@ class SelfInformer:
             src_owner_id=owner.id,
             src_service_type=self.service_type,
             dst_owner_id=owner.id,
-            dst_service_type="broadcast",
+            dst_service_type=BROADCAST_SERVICE_TYPE,
             payload=payload,
         )
 

--- a/opencda/core/application/behavior/services/self_informer/service.py
+++ b/opencda/core/application/behavior/services/self_informer/service.py
@@ -12,6 +12,7 @@ from opencda.core.application.behavior.registry import BehaviorServiceRegistry
 from opencda.core.application.behavior.transport_message import TransportMessage, BROADCAST_SERVICE_TYPE
 from .messages import SelfInformerResponse
 from .utils import get_speed
+from .types import SelfInformerState
 from opencda.core.application.behavior.types import Location
 
 if TYPE_CHECKING:
@@ -38,6 +39,8 @@ class SelfInformer:
         """Initialize the self-informer behavior service."""
         self._owner_ref: weakref.ReferenceType[VehicleManager] | None = None
         self.priority = priority
+        self.location: Location | None = None
+        self.speed: float | None = None
 
     def _get_owner(self) -> VehicleManager:
         owner_ref = self._owner_ref
@@ -58,17 +61,26 @@ class SelfInformer:
         """Release service resources before the participant is destroyed."""
         self._owner_ref = None
 
-    def get_state(self) -> Any:
+    def get_state(self) -> SelfInformerState:
         """Return an immutable snapshot of the current service state."""
-        pass
+        owner = self._get_owner()
+        if self.location is None or self.speed is None:
+            self.location = Location.from_carla(owner.vehicle.get_location())
+            self.speed = get_speed(owner.vehicle)
+        return SelfInformerState(
+            service_type=self.service_type,
+            owner_id=owner.id,
+            location=self.location,
+            speed=self.speed,
+        )
 
     def _build_self_informer_response(
         self,
     ) -> TransportMessage[SelfInformerResponse]:
         owner = self._get_owner()
-        current_location = Location.from_carla(owner.vehicle.get_location())
-        current_speed = get_speed(owner.vehicle)
-        payload = SelfInformerResponse(location=current_location, speed=current_speed)
+        self.location = Location.from_carla(owner.vehicle.get_location())
+        self.speed = get_speed(owner.vehicle)
+        payload = SelfInformerResponse(location=self.location, speed=self.speed)
         return TransportMessage(
             src_owner_id=owner.id,
             src_service_type=self.service_type,

--- a/opencda/core/application/behavior/services/self_informer/types.py
+++ b/opencda/core/application/behavior/services/self_informer/types.py
@@ -4,7 +4,8 @@ from opencda.core.application.behavior.types import Location
 
 
 @dataclass(frozen=True, slots=True)
-class MovementControllerState:
+class SelfInformerState:
     service_type: str
     owner_id: str | None
-    target_position: Location | None  # noqa: DC01
+    location: Location | None
+    speed: float | None

--- a/opencda/core/application/behavior/services/self_informer/utils.py
+++ b/opencda/core/application/behavior/services/self_informer/utils.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+import carla
+import math
+
+
+def get_speed(vehicle: carla.Vehicle, meters: bool = False) -> float:
+    """
+    Compute speed of a vehicle in Km/h.
+
+    Parameters
+    ----------
+    meters : bool
+        Whether to use m/s (True) or km/h (False).
+
+    vehicle : carla.vehicle
+        The vehicle for which speed is calculated.
+
+    Returns
+    -------
+    speed : float
+        The vehicle speed.
+    """
+    vel = vehicle.get_velocity()
+    vel_meter_per_second = math.sqrt(vel.x**2 + vel.y**2 + vel.z**2)
+    return vel_meter_per_second if meters else 3.6 * vel_meter_per_second

--- a/opencda/core/application/behavior/transport_message.py
+++ b/opencda/core/application/behavior/transport_message.py
@@ -4,6 +4,8 @@ from typing import Generic, TypeVar
 
 from dataclasses import dataclass
 
+BROADCAST_OWNER_ID = "broadcast"
+BROADCAST_SERVICE_TYPE = "broadcast"
 
 payloadT = TypeVar("payloadT", covariant=True)
 

--- a/opencda/core/application/behavior/types.py
+++ b/opencda/core/application/behavior/types.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+import carla
 
 
 @dataclass(frozen=True)
@@ -25,6 +26,10 @@ class Location:
             z=self.z - other.z,
         )
 
+    @classmethod
+    def from_carla(cls, other: carla.Location) -> "Location":
+        return cls(x=other.x, y=other.y, z=other.z)
+
 
 @dataclass(frozen=True)
 class Rotation:
@@ -32,8 +37,16 @@ class Rotation:
     yaw: float = 0
     roll: float = 0
 
+    @classmethod
+    def from_carla(cls, other: carla.Rotation) -> "Rotation":
+        return cls(pitch=other.pitch, yaw=other.yaw, roll=other.roll)
+
 
 @dataclass(frozen=True)
 class Transform:
     location: Location = Location()
     rotation: Rotation = Rotation()
+
+    @classmethod
+    def from_carla(cls, other: carla.Transform) -> "Transform":
+        return cls(location=Location.from_carla(other.location), rotation=Rotation.from_carla(other.rotation))

--- a/opencda/core/common/rsu_manager.py
+++ b/opencda/core/common/rsu_manager.py
@@ -9,7 +9,7 @@ from opencda.core.application.behavior import BehaviorService, create_service
 from opencda.core.common.data_dumper import DataDumper
 from opencda.core.sensing.perception.perception_manager import PerceptionManager, PerceptionRequirements
 from opencda.core.sensing.localization.rsu_localization_manager import LocalizationManager
-from opencda.core.application.behavior import TransportMessage
+from opencda.core.application.behavior import TransportMessage, BROADCAST_OWNER_ID
 
 logger = logging.getLogger("cavise.opencda.opencda.core.common.rsu_manager")
 
@@ -236,7 +236,7 @@ class RSUManager(object):
                 if service_type not in self._behavior_services_by_name:
                     raise ValueError(f"Behavior service message references unknown service_type {service_type!r}.")
                 valid_messages.append(message)
-            elif owner_id == "broadcast" and message.src_owner_id != self.id:
+            elif owner_id == BROADCAST_OWNER_ID and message.src_owner_id != self.id:
                 if service_type in self._behavior_services_by_name:
                     valid_messages.append(message)
 

--- a/opencda/core/common/vehicle_manager.py
+++ b/opencda/core/common/vehicle_manager.py
@@ -292,13 +292,14 @@ class VehicleManager(object):
                     raise ValueError(f"Behavior service message references unknown service_type {service_type!r}.")
                 valid_messages.append(message)
             elif owner_id == "broadcast" and message.src_owner_id != self.id:
-                if service_type in self._behavior_services_by_name:
+                if service_type in self._behavior_services_by_name or service_type == "broadcast":
                     valid_messages.append(message)
 
         return valid_messages
 
     def __group_behavior_service_messages(self, messages: list[TransportMessage]) -> Mapping[str, list[TransportMessage]]:
-        grouped_messages: Mapping[str, list[TransportMessage]] = {service.service_type: [] for service in self.behavior_services}
+        grouped_messages: dict[str, list[TransportMessage]] = {service.service_type: [] for service in self.behavior_services}
+        grouped_messages["broadcast"] = []
 
         for message in messages:
             grouped_messages[message.dst_service_type].append(message)
@@ -312,6 +313,8 @@ class VehicleManager(object):
 
         for service in self.behavior_services:
             service_messages = grouped_messages[service.service_type]
+            if "broadcast" in grouped_messages:
+                service_messages += grouped_messages["broadcast"]
             result_messages = service.process(service_messages)
             self.behavior_service_states[service.service_type] = service.get_state()
             if result_messages:

--- a/opencda/core/common/vehicle_manager.py
+++ b/opencda/core/common/vehicle_manager.py
@@ -9,7 +9,7 @@ from typing import Any, Iterable, Optional, Sequence, Tuple, Mapping
 import carla
 
 from opencda.core.actuation.control_manager import ControlManager
-from opencda.core.application.behavior import BehaviorService, TransportMessage, create_service
+from opencda.core.application.behavior import BehaviorService, TransportMessage, BROADCAST_OWNER_ID, BROADCAST_SERVICE_TYPE, create_service
 from opencda.core.application.platooning.platoon_behavior_agent import PlatooningBehaviorAgent
 from opencda.core.common.v2x_manager import V2XManager
 from opencda.core.sensing.localization.localization_manager import LocalizationManager
@@ -291,15 +291,15 @@ class VehicleManager(object):
                 if service_type not in self._behavior_services_by_name:
                     raise ValueError(f"Behavior service message references unknown service_type {service_type!r}.")
                 valid_messages.append(message)
-            elif owner_id == "broadcast" and message.src_owner_id != self.id:
-                if service_type in self._behavior_services_by_name or service_type == "broadcast":
+            elif owner_id == BROADCAST_OWNER_ID and message.src_owner_id != self.id:
+                if service_type in self._behavior_services_by_name or service_type == BROADCAST_SERVICE_TYPE:
                     valid_messages.append(message)
 
         return valid_messages
 
     def __group_behavior_service_messages(self, messages: list[TransportMessage]) -> Mapping[str, list[TransportMessage]]:
         grouped_messages: dict[str, list[TransportMessage]] = {service.service_type: [] for service in self.behavior_services}
-        grouped_messages["broadcast"] = []
+        grouped_messages[BROADCAST_SERVICE_TYPE] = []
 
         for message in messages:
             grouped_messages[message.dst_service_type].append(message)
@@ -313,8 +313,8 @@ class VehicleManager(object):
 
         for service in self.behavior_services:
             service_messages = grouped_messages[service.service_type]
-            if "broadcast" in grouped_messages:
-                service_messages += grouped_messages["broadcast"]
+            if BROADCAST_SERVICE_TYPE in grouped_messages:
+                service_messages += grouped_messages[BROADCAST_SERVICE_TYPE]
             result_messages = service.process(service_messages)
             self.behavior_service_states[service.service_type] = service.get_state()
             if result_messages:

--- a/opencda/scenario_testing/config_yaml/aim_check.yaml
+++ b/opencda/scenario_testing/config_yaml/aim_check.yaml
@@ -113,6 +113,7 @@ scenario:
       id: 100
       color: [156, 255, 206]
       behavior_services:
+        - type: self_informer
         - type: aim_client
           debug: true
         - type: movement_controller
@@ -123,6 +124,7 @@ scenario:
       id: 200
       color: [156, 255, 206]
       behavior_services:
+        - type: self_informer
         - type: aim_client
           debug: true
         - type: movement_controller
@@ -133,6 +135,7 @@ scenario:
       id: 300
       color: [156, 255, 206]
       behavior_services:
+        - type: self_informer
         - type: aim_client
           debug: true
         - type: movement_controller
@@ -143,6 +146,7 @@ scenario:
       id: 400
       color: [156, 255, 206]
       behavior_services:
+        - type: self_informer
         - type: aim_client
           debug: true
         - type: movement_controller

--- a/opencda/scenario_testing/config_yaml/codriving_check.yaml
+++ b/opencda/scenario_testing/config_yaml/codriving_check.yaml
@@ -110,5 +110,6 @@ scenario:
       v2x:
         communication_range: 45
       behavior_services:
+        - type: self_informer
         - type: aim_client
         - type: movement_controller

--- a/opencda/scenario_testing/config_yaml/default.yaml
+++ b/opencda/scenario_testing/config_yaml/default.yaml
@@ -163,6 +163,7 @@ vehicle_base:
     enabled: true
     communication_range: 35
   behavior_services:
+    - type: self_informer
     - type: movement_controller
 
 


### PR DESCRIPTION
## Summary

<!-- What does this PR change? Why is it needed? -->
Adds a `self_informer` behavior service that publishes each CAV's current location and speed as a local broadcast message for other behavior services on the same vehicle. 

## Related issue

<!-- Use Closes #123 only if this PR fully resolves the issue. -->


## Changes

- Added `self_informer` service, message type, and speed utility for publishing current CAV state.
- Added local broadcast routing support so vehicle behavior services can receive shared intra-vehicle messages.
- Updated `aim_client` to consume `SelfInformerResponse` when calculating target speeds for AIM trajectories.
- Added broadcast owner/service constants and replaced raw broadcast string literals in behavior routing.
- Added CARLA conversion helpers for behavior `Location`, `Rotation`, and `Transform`.
- Updated scenario configs to include `self_informer` in vehicle behavior service stacks.

## Validation

<!-- How was this tested or validated? -->

- [x] Simulation run
- [x] Manual verification
- [ ] Not applicable

## Checklist

- [x] Linked the related issue
- [x] Kept the PR focused and reviewable
- [ ] Updated documentation if needed
- [x] Added or updated validation steps if needed
