### PR TITLE
[attacks] Added base stages for attacks

### DIFF
--- a/opencda/core/attack/advcp/adv_coperception_model_manager.py
+++ b/opencda/core/attack/advcp/adv_coperception_model_manager.py
@@ -6,7 +6,7 @@ from typing import Any, Mapping, Optional, cast
 
 import numpy as np
 import numpy.typing as npt
-import yaml  # type: ignore
+import yaml
 
 from opencda.core.attack.advcp.attack_helper import AdvCPAttackHelper
 from opencda.core.attack.advcp.early_fusion_attack import AdvCoperceptionEarlyFusionAttack

--- a/opencda/core/attack/adversary_framework/attack.py
+++ b/opencda/core/attack/adversary_framework/attack.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from typing import Any
 
 from opencda.core.application.behavior.behavior_service_protocol import BehaviorService
@@ -12,6 +13,8 @@ from .condition_evaluator import evaluate_condition
 from .models import AttackSpec, AttackStageResult, RuntimeStatus, StageRuntime, Status
 from .stage_registry import AttackStageRegistry
 from .utils import ServiceResolver, match_services, resolve_targets as resolve_configured_targets
+
+logger = logging.getLogger("cavise.opencda.opencda.core.attack.adversary_framework.attack")
 
 
 class Attack:
@@ -160,6 +163,7 @@ class Attack:
                 )
                 stage_runtime.last_result = stop_result
                 self._set_stage_status(stage_runtime, RuntimeStatus.SUCCESS)
+                self._log_stage_result(stage_runtime, stop_result)
                 emitted_results.append(stop_result)
 
         progress = True
@@ -189,12 +193,14 @@ class Attack:
                     )
                     stage_runtime.last_result = fail_result
                     self._set_stage_status(stage_runtime, RuntimeStatus.FAIL)
+                    self._log_stage_result(stage_runtime, fail_result)
                     self.mark_failed()
                     emitted_results.append(fail_result)
                     return tuple(emitted_results)
 
                 stage_result = stage_runtime.stage.execute(matched_services)
                 stage_runtime.last_result = stage_result
+                self._log_stage_result(stage_runtime, stage_result)
                 emitted_results.append(stage_result)
 
                 if stage_result.status == Status.FAIL:
@@ -283,10 +289,38 @@ class Attack:
             deactivate()
 
     def _set_attack_status(self, status: RuntimeStatus) -> None:
+        if self.status != status:
+            logger.info(
+                "Attack '%s' status changed: %s -> %s.",
+                self.attack_name,
+                self.status.value,
+                status.value,
+            )
         self.previous_status = self.status
         self.status = status
 
-    @staticmethod
-    def _set_stage_status(stage_runtime: StageRuntime, status: RuntimeStatus) -> None:
+    def _set_stage_status(self, stage_runtime: StageRuntime, status: RuntimeStatus) -> None:
+        if stage_runtime.status != status:
+            logger.info(
+                "Attack '%s' stage '%s' status changed: %s -> %s.",
+                self.attack_name,
+                stage_runtime.spec.id,
+                stage_runtime.status.value,
+                status.value,
+            )
         stage_runtime.previous_status = stage_runtime.status
         stage_runtime.status = status
+
+    def _log_stage_result(self, stage_runtime: StageRuntime, stage_result: AttackStageResult) -> None:
+        log_message = "Attack '%s' stage '%s' emitted result: status=%s, stage_name=%s, reason=%s."
+        log_args = (
+            self.attack_name,
+            stage_runtime.spec.id,
+            stage_result.status.value,
+            stage_result.stage_name,
+            stage_result.reason,
+        )
+        if stage_result.status == Status.FAIL:
+            logger.warning(log_message, *log_args)
+            return
+        logger.info(log_message, *log_args)

--- a/opencda/core/attack/adversary_framework/attack.py
+++ b/opencda/core/attack/adversary_framework/attack.py
@@ -135,7 +135,12 @@ class Attack:
         service_resolver: ServiceResolver,
     ) -> tuple[BehaviorService[Any, Any], ...]:
         """Resolve live target services according to `spec.targets`."""
-        return resolve_configured_targets(self.spec.targets, current_snapshot, service_resolver)
+        return resolve_configured_targets(
+            self.spec.targets,
+            current_snapshot,
+            service_resolver,
+            attack_name=self.attack_name,
+        )
 
     def run_stage_lifecycle(
         self,

--- a/opencda/core/attack/adversary_framework/attack.py
+++ b/opencda/core/attack/adversary_framework/attack.py
@@ -36,7 +36,17 @@ class Attack:
     @classmethod
     def from_spec(cls, spec: AttackSpec) -> Attack:
         """Build a generic runtime attack from config and stage registry."""
-        stages = tuple(AttackStageRegistry.create_stage(stage_spec.type) for stage_spec in spec.stages)
+        stages = tuple(
+            AttackStageRegistry.create_stage(
+                stage_spec.type,
+                **(
+                    {"capabilities": stage_spec.capabilities, "params": stage_spec.params}
+                    if stage_spec.params is not None
+                    else {"capabilities": stage_spec.capabilities}
+                ),
+            )
+            for stage_spec in spec.stages
+        )
         return cls(spec=spec, stages=stages)
 
     def mark_started(self) -> None:
@@ -169,12 +179,13 @@ class Attack:
                 if not self._should_start_stage(index, stage_runtime, previous_snapshot, current_snapshot):
                     continue
 
-                matched_services = tuple(match_services(available_services, stage_runtime.stage.required_capabilities))
+                matched_services = tuple(match_services(available_services, stage_runtime.stage.capabilities))
                 if not matched_services:
+                    configured_capabilities = ", ".join(capability.value for capability in stage_runtime.stage.capabilities)
                     fail_result = AttackStageResult(
                         stage_name=stage_runtime.stage.stage_name,
                         status=Status.FAIL,
-                        reason=f"No services matched required capabilities for stage '{stage_runtime.spec.id}'.",
+                        reason=(f"No services matched configured capabilities [{configured_capabilities}] for stage '{stage_runtime.spec.id}'."),
                     )
                     stage_runtime.last_result = fail_result
                     self._set_stage_status(stage_runtime, RuntimeStatus.FAIL)

--- a/opencda/core/attack/adversary_framework/attack.py
+++ b/opencda/core/attack/adversary_framework/attack.py
@@ -295,7 +295,7 @@ class Attack:
 
     def _set_attack_status(self, status: RuntimeStatus) -> None:
         if self.status != status:
-            logger.info(
+            logger.debug(
                 "Attack '%s' status changed: %s -> %s.",
                 self.attack_name,
                 self.status.value,
@@ -306,7 +306,7 @@ class Attack:
 
     def _set_stage_status(self, stage_runtime: StageRuntime, status: RuntimeStatus) -> None:
         if stage_runtime.status != status:
-            logger.info(
+            logger.debug(
                 "Attack '%s' stage '%s' status changed: %s -> %s.",
                 self.attack_name,
                 stage_runtime.spec.id,
@@ -328,4 +328,4 @@ class Attack:
         if stage_result.status == Status.FAIL:
             logger.warning(log_message, *log_args)
             return
-        logger.info(log_message, *log_args)
+        logger.debug(log_message, *log_args)

--- a/opencda/core/attack/adversary_framework/attack_manager.py
+++ b/opencda/core/attack/adversary_framework/attack_manager.py
@@ -3,12 +3,15 @@
 from __future__ import annotations
 
 from collections.abc import Iterable
+import logging
 
 from opencda.scenario_testing.types import SimulationSnapshot
 
 from .attack import Attack
 from .models import AttackResult, AttackStageResult, RuntimeStatus, Status
 from .utils import ServiceResolver
+
+logger = logging.getLogger("cavise.opencda.opencda.core.attack.adversary_framework.attack_manager")
 
 
 class AttackManager:
@@ -34,20 +37,22 @@ class AttackManager:
                     stage_history = attack.get_stage_history()
                     attack.deactivate()
                     attack.mark_stopped()
-                    results.append(
-                        AttackResult(
-                            attack_name=attack.attack_name,
-                            status=Status.STOP,
-                            reason="Attack stop trigger fired.",
-                            stage_history=stage_history,
-                        )
+                    attack_result = AttackResult(
+                        attack_name=attack.attack_name,
+                        status=Status.STOP,
+                        reason="Attack stop trigger fired.",
+                        stage_history=stage_history,
                     )
+                    self._log_attack_result(attack_result)
+                    results.append(attack_result)
                     continue
 
                 target_services = tuple(attack.resolve_targets(current_snapshot, service_resolver))
                 stage_results = attack.run_stage_lifecycle(previous_snapshot, current_snapshot, target_services)
                 if stage_results:
-                    results.append(self._build_attack_result(attack, stage_results))
+                    attack_result = self._build_attack_result(attack, stage_results)
+                    self._log_attack_result(attack_result)
+                    results.append(attack_result)
                 continue
 
             if not attack.should_start(previous_snapshot, current_snapshot):
@@ -55,13 +60,13 @@ class AttackManager:
 
             target_services = tuple(attack.resolve_targets(current_snapshot, service_resolver))
             if not target_services:
-                results.append(
-                    AttackResult(
-                        attack_name=attack.attack_name,
-                        status=Status.FAIL,
-                        reason="Attack trigger fired, but no target services were resolved.",
-                    )
+                attack_result = AttackResult(
+                    attack_name=attack.attack_name,
+                    status=Status.FAIL,
+                    reason="Attack trigger fired, but no target services were resolved.",
                 )
+                self._log_attack_result(attack_result)
+                results.append(attack_result)
                 continue
 
             attack.mark_started()
@@ -69,7 +74,9 @@ class AttackManager:
             if attack.status == RuntimeStatus.STARTED:
                 attack.mark_active()
             if stage_results:
-                results.append(self._build_attack_result(attack, stage_results))
+                attack_result = self._build_attack_result(attack, stage_results)
+                self._log_attack_result(attack_result)
+                results.append(attack_result)
 
         self.previous_snapshot = current_snapshot
         return tuple(results)
@@ -102,3 +109,16 @@ class AttackManager:
             reason=last_result.reason,
             stage_history=attack.get_stage_history(),
         )
+
+    @staticmethod
+    def _log_attack_result(attack_result: AttackResult) -> None:
+        log_message = "Attack '%s' result: status=%s, reason=%s."
+        log_args = (
+            attack_result.attack_name,
+            attack_result.status.value,
+            attack_result.reason,
+        )
+        if attack_result.status == Status.FAIL:
+            logger.warning(log_message, *log_args)
+            return
+        logger.info(log_message, *log_args)

--- a/opencda/core/attack/adversary_framework/attack_stage_protocol.py
+++ b/opencda/core/attack/adversary_framework/attack_stage_protocol.py
@@ -16,7 +16,9 @@ class AttackStage(Protocol):
     """Single executable attack stage."""
 
     stage_name: str
-    required_capabilities: Collection[Capability]
+    supported_capabilities: Collection[Capability]
+    default_capabilities: Collection[Capability]
+    capabilities: Collection[Capability]
     description: str  # noqa: DC01
 
     def execute(self, services: Sequence[BehaviorService[Any, Any]]) -> AttackStageResult:

--- a/opencda/core/attack/adversary_framework/attacks/aim_client_identity_spoofing/config.yaml
+++ b/opencda/core/attack/adversary_framework/attacks/aim_client_identity_spoofing/config.yaml
@@ -1,0 +1,67 @@
+attack:
+  name: aim_client_identity_spoofing
+
+  requirements:
+    all:
+      - source:
+          kind: snapshot
+          node_type: rsu
+          service_type: aim_server
+        verb: exists
+      - source:
+          kind: snapshot
+          node_type: vehicle
+          service_type: aim_client
+        verb: exists
+
+  start_trigger:
+    source:
+      kind: snapshot
+      node_type: rsu
+      service_type: aim_server
+      field: tracked_vehicle_count
+    verb: gte
+    value: 2
+
+  stop_trigger:
+    source:
+      kind: snapshot
+      node_type: rsu
+      service_type: aim_server
+      field: tracked_vehicle_count
+    verb: eq
+    value: 0
+
+  targets:
+    kind: service_state_field
+    source:
+      kind: snapshot
+      node_type: rsu
+      service_type: aim_server
+      field: tracked_vehicle_ids
+    resolve_to:
+      node_type: vehicle
+      service_type: aim_client
+    selection: first
+
+  stages:
+    - id: spoof_selected_aim_client_identity
+      type: spoofer
+      capabilities:
+        - request.submit
+      params:
+        rewrites:
+          - path: src_owner_id
+            operation: set
+            value: cav-spoofed
+          - path: payload.vehicle_id
+            operation: set
+            value: cav-spoofed
+      stage_stop_trigger:
+        source:
+          kind: snapshot
+          node_type: rsu
+          service_type: aim_server
+          field: tracked_vehicle_count
+        verb: eq
+        value: 0

--- a/opencda/core/attack/adversary_framework/attacks/aim_client_request_position_spoofing/config.yaml
+++ b/opencda/core/attack/adversary_framework/attacks/aim_client_request_position_spoofing/config.yaml
@@ -1,0 +1,64 @@
+attack:
+  name: aim_client_request_position_spoofing
+
+  requirements:
+    all:
+      - source:
+          kind: snapshot
+          node_type: rsu
+          service_type: aim_server
+        verb: exists
+      - source:
+          kind: snapshot
+          node_type: vehicle
+          service_type: aim_client
+        verb: exists
+
+  start_trigger:
+    source:
+      kind: snapshot
+      node_type: rsu
+      service_type: aim_server
+      field: tracked_vehicle_count
+    verb: gte
+    value: 2
+
+  stop_trigger:
+    source:
+      kind: snapshot
+      node_type: rsu
+      service_type: aim_server
+      field: tracked_vehicle_count
+    verb: eq
+    value: 0
+
+  targets:
+    kind: service_state_field
+    source:
+      kind: snapshot
+      node_type: rsu
+      service_type: aim_server
+      field: tracked_vehicle_ids
+    resolve_to:
+      node_type: vehicle
+      service_type: aim_client
+    selection: first
+
+  stages:
+    - id: spoof_selected_aim_client_position
+      type: spoofer
+      capabilities:
+        - request.submit
+      params:
+        rewrites:
+          - path: payload.position.location.x
+            operation: add
+            value: -20.0
+      stage_stop_trigger:
+        source:
+          kind: snapshot
+          node_type: rsu
+          service_type: aim_server
+          field: tracked_vehicle_count
+        verb: eq
+        value: 0

--- a/opencda/core/attack/adversary_framework/attacks/aim_client_request_speed_spoofing/config.yaml
+++ b/opencda/core/attack/adversary_framework/attacks/aim_client_request_speed_spoofing/config.yaml
@@ -1,0 +1,66 @@
+attack:
+  name: aim_client_request_speed_spoofing
+
+  requirements:
+    all:
+      - source:
+          kind: snapshot
+          node_type: rsu
+          service_type: aim_server
+        verb: exists
+      - source:
+          kind: snapshot
+          node_type: vehicle
+          service_type: aim_client
+        verb: exists
+
+  start_trigger:
+    source:
+      kind: snapshot
+      node_type: rsu
+      service_type: aim_server
+      field: tracked_vehicle_count
+    verb: increased
+    value: 1
+
+  stop_trigger:
+    source:
+      kind: snapshot
+      node_type: rsu
+      service_type: aim_server
+      field: tracked_vehicle_count
+    verb: eq
+    value: 0
+
+  targets:
+    kind: service_state_field
+    source:
+      kind: snapshot
+      node_type: rsu
+      service_type: aim_server
+      field: tracked_vehicle_ids
+    resolve_to:
+      node_type: vehicle
+      service_type: aim_client
+
+  stages:
+    - id: spoof_aim_client_requests
+      type: spoofer
+      capabilities:
+        - request.submit
+      params:
+        rewrites:
+          - path: payload.speed
+            operation: add
+            value: 5.0
+          - path: payload.yaw
+            operation: add
+            value: 10.0
+      stage_stop_trigger:
+        source:
+          kind: snapshot
+          node_type: rsu
+          service_type: aim_server
+          field: tracked_vehicle_count
+        verb: eq
+        value: 0

--- a/opencda/core/attack/adversary_framework/attacks/aim_client_reservation_stealing/config.yaml
+++ b/opencda/core/attack/adversary_framework/attacks/aim_client_reservation_stealing/config.yaml
@@ -1,0 +1,67 @@
+attack:
+  name: aim_client_reservation_stealing
+
+  requirements:
+    all:
+      - source:
+          kind: snapshot
+          node_type: rsu
+          service_type: aim_server
+        verb: exists
+      - source:
+          kind: snapshot
+          node_type: vehicle
+          service_type: aim_client
+        verb: exists
+
+  start_trigger:
+    source:
+      kind: snapshot
+      node_type: rsu
+      service_type: aim_server
+      field: tracked_vehicle_count
+    verb: gte
+    value: 2
+
+  stop_trigger:
+    source:
+      kind: snapshot
+      node_type: rsu
+      service_type: aim_server
+      field: tracked_vehicle_count
+    verb: eq
+    value: 0
+
+  targets:
+    kind: service_state_field
+    source:
+      kind: snapshot
+      node_type: rsu
+      service_type: aim_server
+      field: tracked_vehicle_ids
+    resolve_to:
+      node_type: vehicle
+      service_type: aim_client
+    selection: first
+
+  stages:
+    - id: steal_reservation_for_selected_aim_client
+      type: spoofer
+      capabilities:
+        - request.submit
+      params:
+        rewrites:
+          - path: payload.position.location.x
+            operation: add
+            value: -25.0
+          - path: payload.speed
+            operation: add
+            value: 8.0
+      stage_stop_trigger:
+        source:
+          kind: snapshot
+          node_type: rsu
+          service_type: aim_server
+          field: tracked_vehicle_count
+        verb: eq
+        value: 0

--- a/opencda/core/attack/adversary_framework/attacks/aim_client_response_sniffer/config.yaml
+++ b/opencda/core/attack/adversary_framework/attacks/aim_client_response_sniffer/config.yaml
@@ -46,6 +46,8 @@ attack:
   stages:
     - id: sniff_aim_client_responses
       type: sniffer
+      capabilities:
+        - response.observe
       stage_start_trigger:
         source:
           kind: attack

--- a/opencda/core/attack/adversary_framework/attacks/aim_server_request_replay/config.yaml
+++ b/opencda/core/attack/adversary_framework/attacks/aim_server_request_replay/config.yaml
@@ -1,0 +1,58 @@
+attack:
+  name: aim_server_request_replay
+
+  requirements:
+    all:
+      - source:
+          kind: snapshot
+          node_type: rsu
+          service_type: aim_server
+        verb: exists
+      - source:
+          kind: snapshot
+          node_type: vehicle
+          service_type: aim_client
+        verb: exists
+
+  start_trigger:
+    source:
+      kind: snapshot
+      node_type: rsu
+      service_type: aim_server
+      field: tracked_vehicle_count
+    verb: increased
+    value: 1
+
+  stop_trigger:
+    source:
+      kind: snapshot
+      node_type: rsu
+      service_type: aim_server
+      field: tracked_vehicle_count
+    verb: eq
+    value: 0
+
+  targets:
+    kind: service_state_field
+    source:
+      kind: snapshot
+      node_type: rsu
+      service_type: aim_server
+      field: owner_id
+    resolve_to:
+      node_type: rsu
+      service_type: aim_server
+
+  stages:
+    - id: replay_aim_server_requests
+      type: replayer
+      capabilities:
+        - request.observe
+      stage_stop_trigger:
+        source:
+          kind: snapshot
+          node_type: rsu
+          service_type: aim_server
+          field: tracked_vehicle_count
+        verb: eq
+        value: 0

--- a/opencda/core/attack/adversary_framework/attacks/aim_server_response_jamming/config.yaml
+++ b/opencda/core/attack/adversary_framework/attacks/aim_server_response_jamming/config.yaml
@@ -1,0 +1,58 @@
+attack:
+  name: aim_server_response_jamming
+
+  requirements:
+    all:
+      - source:
+          kind: snapshot
+          node_type: rsu
+          service_type: aim_server
+        verb: exists
+      - source:
+          kind: snapshot
+          node_type: vehicle
+          service_type: aim_client
+        verb: exists
+
+  start_trigger:
+    source:
+      kind: snapshot
+      node_type: rsu
+      service_type: aim_server
+      field: tracked_vehicle_count
+    verb: increased
+    value: 1
+
+  stop_trigger:
+    source:
+      kind: snapshot
+      node_type: rsu
+      service_type: aim_server
+      field: tracked_vehicle_count
+    verb: eq
+    value: 0
+
+  targets:
+    kind: service_state_field
+    source:
+      kind: snapshot
+      node_type: rsu
+      service_type: aim_server
+      field: owner_id
+    resolve_to:
+      node_type: rsu
+      service_type: aim_server
+
+  stages:
+    - id: drop_aim_server_responses
+      type: dropper
+      capabilities:
+        - response.submit
+      stage_stop_trigger:
+        source:
+          kind: snapshot
+          node_type: rsu
+          service_type: aim_server
+          field: tracked_vehicle_count
+        verb: eq
+        value: 0

--- a/opencda/core/attack/adversary_framework/attacks/aim_server_response_replay/config.yaml
+++ b/opencda/core/attack/adversary_framework/attacks/aim_server_response_replay/config.yaml
@@ -6,19 +6,19 @@ attack:
       - source:
           kind: snapshot
           node_type: rsu
-          service_name: aim_server
+          service_type: aim_server
         verb: exists
       - source:
           kind: snapshot
           node_type: vehicle
-          service_name: aim_client
+          service_type: aim_client
         verb: exists
 
   start_trigger:
     source:
       kind: snapshot
       node_type: rsu
-      service_name: aim_server
+      service_type: aim_server
       field: tracked_vehicle_count
     verb: increased
     value: 1
@@ -27,7 +27,7 @@ attack:
     source:
       kind: snapshot
       node_type: rsu
-      service_name: aim_server
+      service_type: aim_server
       field: tracked_vehicle_count
     verb: eq
     value: 0
@@ -37,20 +37,22 @@ attack:
     source:
       kind: snapshot
       node_type: rsu
-      service_name: aim_server
+      service_type: aim_server
       field: owner_id
     resolve_to:
       node_type: rsu
-      service_name: aim_server
+      service_type: aim_server
 
   stages:
     - id: replay_aim_server_responses
-      type: response_replayer
+      type: replayer
+      capabilities:
+        - response.submit
       stage_stop_trigger:
         source:
           kind: snapshot
           node_type: rsu
-          service_name: aim_server
+          service_type: aim_server
           field: tracked_vehicle_count
         verb: eq
         value: 0

--- a/opencda/core/attack/adversary_framework/models/attack_spec.py
+++ b/opencda/core/attack/adversary_framework/models/attack_spec.py
@@ -84,7 +84,7 @@ class TargetSpec:
     kind: str
     source: TriggerSourceSpec
     resolve_to_node_type: str  # noqa: DC01
-    resolve_to_service_name: str
+    resolve_to_service_name: str | None
     selection: str = "all"
 
     @classmethod
@@ -94,7 +94,7 @@ class TargetSpec:
             kind=str(data["kind"]),
             source=TriggerSourceSpec.from_dict(data["source"]),
             resolve_to_node_type=str(resolve_to["node_type"]),
-            resolve_to_service_name=str(resolve_to["service_type"]),
+            resolve_to_service_name=(str(resolve_to["service_type"]) if resolve_to.get("service_type") is not None else None),
             selection=str(data.get("selection", "all")),
         )
 

--- a/opencda/core/attack/adversary_framework/models/attack_spec.py
+++ b/opencda/core/attack/adversary_framework/models/attack_spec.py
@@ -85,6 +85,7 @@ class TargetSpec:
     source: TriggerSourceSpec
     resolve_to_node_type: str  # noqa: DC01
     resolve_to_service_name: str
+    selection: str = "all"
 
     @classmethod
     def from_dict(cls, data: Mapping[str, Any]) -> TargetSpec:
@@ -94,6 +95,7 @@ class TargetSpec:
             source=TriggerSourceSpec.from_dict(data["source"]),
             resolve_to_node_type=str(resolve_to["node_type"]),
             resolve_to_service_name=str(resolve_to["service_type"]),
+            selection=str(data.get("selection", "all")),
         )
 
 

--- a/opencda/core/attack/adversary_framework/models/attack_spec.py
+++ b/opencda/core/attack/adversary_framework/models/attack_spec.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Mapping
 
+from opencda.core.application.behavior.capability import Capability
+
 
 @dataclass(frozen=True, slots=True)
 class TriggerSourceSpec:
@@ -101,19 +103,35 @@ class StageSpec:
 
     id: str
     type: str
+    capabilities: tuple[Capability, ...] | None = None
+    params: Mapping[str, Any] | None = None
     requirements: ConditionSpec | None = None
     stage_start_trigger: ConditionSpec | None = None
     stage_stop_trigger: ConditionSpec | None = None
+
+    def __post_init__(self) -> None:
+        if self.capabilities is not None and not self.capabilities:
+            raise ValueError("StageSpec must define at least one capability.")
 
     @classmethod
     def from_dict(cls, data: Mapping[str, Any]) -> StageSpec:
         requirements = data.get("requirements")
         stage_start_trigger = data.get("stage_start_trigger")
         stage_stop_trigger = data.get("stage_stop_trigger")
+        configured_capabilities = data.get("capabilities")
+        params = data.get("params")
+        if isinstance(configured_capabilities, str):
+            configured_capabilities = (configured_capabilities,)
+        if params is not None and not isinstance(params, Mapping):
+            raise ValueError(f"Stage '{data.get('id', '<unknown>')}' has invalid 'params'; expected a mapping.")
 
         return cls(
             id=str(data["id"]),
             type=str(data["type"]),
+            capabilities=(
+                tuple(Capability(str(capability)) for capability in configured_capabilities) if configured_capabilities is not None else None
+            ),
+            params=dict(params) if params is not None else None,
             requirements=ConditionSpec.from_dict(requirements) if requirements is not None else None,
             stage_start_trigger=ConditionSpec.from_dict(stage_start_trigger) if stage_start_trigger is not None else None,
             stage_stop_trigger=ConditionSpec.from_dict(stage_stop_trigger) if stage_stop_trigger is not None else None,

--- a/opencda/core/attack/adversary_framework/stage_registry.py
+++ b/opencda/core/attack/adversary_framework/stage_registry.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+from collections.abc import Collection
 import inspect
 import logging
 from typing import Any, TypeVar, cast
+
+from opencda.core.application.behavior.capability import Capability
 
 from .attack_stage_protocol import AttackStage
 
@@ -46,9 +49,67 @@ class AttackStageRegistry:
     def create_stage(cls, stage_name: str, **kwargs: Any) -> AttackStage:
         """Instantiate an attack stage by name."""
         stage_cls = cls.get_stage_class(stage_name=stage_name)
+        configured_capabilities = kwargs.get("capabilities")
+        supported_capabilities = tuple(getattr(stage_cls, "supported_capabilities", ()))
+        default_capabilities = tuple(getattr(stage_cls, "default_capabilities", ()))
+
+        if not supported_capabilities:
+            raise ValueError(f"Attack stage '{stage_name}' must define non-empty 'supported_capabilities'.")
+
+        if not default_capabilities:
+            raise ValueError(f"Attack stage '{stage_name}' must define non-empty 'default_capabilities'.")
+
+        normalized_default_capabilities = cls._normalize_capabilities(default_capabilities)
+        cls._validate_supported_capabilities(
+            stage_name=stage_name,
+            capabilities=normalized_default_capabilities,
+            supported_capabilities=supported_capabilities,
+            source_label="default",
+        )
+
+        if configured_capabilities is None:
+            normalized_capabilities = normalized_default_capabilities
+        else:
+            normalized_capabilities = cls._normalize_capabilities(configured_capabilities)
+            cls._validate_supported_capabilities(
+                stage_name=stage_name,
+                capabilities=normalized_capabilities,
+                supported_capabilities=supported_capabilities,
+                source_label="configured",
+            )
+
+        kwargs["capabilities"] = normalized_capabilities
         return stage_cls(**kwargs)
+
+    @classmethod
+    def _validate_supported_capabilities(
+        cls,
+        stage_name: str,
+        capabilities: tuple[Capability, ...],
+        supported_capabilities: tuple[Capability, ...],
+        source_label: str,
+    ) -> None:
+        unsupported_capabilities = sorted(
+            set(capabilities).difference(supported_capabilities),
+            key=lambda capability: capability.value,
+        )
+        if unsupported_capabilities:
+            unsupported = ", ".join(capability.value for capability in unsupported_capabilities)
+            supported = ", ".join(capability.value for capability in supported_capabilities)
+            raise ValueError(
+                f"Attack stage '{stage_name}' does not support {source_label} capabilities [{unsupported}]. Supported capabilities: [{supported}]."
+            )
 
     @classmethod
     def list_stages(cls) -> list[str]:
         """List registered attack stages."""
         return sorted(cls._registry)
+
+    @staticmethod
+    def _normalize_capabilities(capabilities: Collection[Capability] | Collection[str]) -> tuple[Capability, ...]:
+        normalized_capabilities = tuple(
+            capability if isinstance(capability, Capability) else Capability(str(capability)) for capability in capabilities
+        )
+        if not normalized_capabilities:
+            raise ValueError("Configured stage capabilities cannot be empty.")
+        return normalized_capabilities

--- a/opencda/core/attack/adversary_framework/stages/dropper/__init__.py
+++ b/opencda/core/attack/adversary_framework/stages/dropper/__init__.py
@@ -1,0 +1,7 @@
+"""Generic dropper stage package."""
+
+from .stage import DropperStage
+
+__all__ = [
+    "DropperStage",
+]

--- a/opencda/core/attack/adversary_framework/stages/dropper/stage.py
+++ b/opencda/core/attack/adversary_framework/stages/dropper/stage.py
@@ -1,39 +1,34 @@
-"""Passive sniffer stage for observing service responses."""
+"""Drop service outputs produced by configured capability handlers."""
 
 from __future__ import annotations
 
 from collections.abc import Sequence
-from copy import deepcopy
-from functools import partial
 from typing import Any
 
 from opencda.core.application.behavior.behavior_service_protocol import BehaviorService
 from opencda.core.application.behavior.capability import Capability
 from opencda.core.attack.adversary_framework.models import AttackStageResult, Status
 from opencda.core.attack.adversary_framework.stage_registry import AttackStageRegistry
-from opencda.core.attack.adversary_framework.stages.sniffer.types import ObservedOutput
 from opencda.core.attack.adversary_framework.utils import RestoreCallback, install_output_interceptor
 
 
 @AttackStageRegistry.register
-class SnifferStage:
-    """Passively observe outputs produced by selected service capabilities."""
+class DropperStage:
+    """Replace selected message-producing outputs with an empty batch."""
 
-    stage_name = "sniffer"
+    stage_name = "dropper"
     supported_capabilities = (
         Capability.REQUEST_OBSERVE,
         Capability.REQUEST_SUBMIT,
         Capability.RESPONSE_OBSERVE,
         Capability.RESPONSE_SUBMIT,
         Capability.COMMAND_SUBMIT,
-        Capability.STATE_OBSERVE,
     )
-    default_capabilities = (Capability.RESPONSE_OBSERVE,)
-    description = "Passively captures outputs returned by the configured capability handlers."  # noqa: DC01
+    default_capabilities = (Capability.RESPONSE_SUBMIT,)
+    description = "Drops outputs returned by the configured message capability handlers."  # noqa: DC01
 
     def __init__(self, capabilities: Sequence[Capability]) -> None:
         self.capabilities = tuple(capabilities)
-        self.observed_outputs: list[ObservedOutput] = []
         self._restore_callbacks: list[RestoreCallback] = []
 
     def execute(self, services: Sequence[BehaviorService[Any, Any]]) -> AttackStageResult:
@@ -43,7 +38,7 @@ class SnifferStage:
             return AttackStageResult(
                 stage_name=self.stage_name,
                 status=Status.FAIL,
-                reason="SnifferStage received no target services.",
+                reason="DropperStage received no target services.",
             )
 
         for service in services:
@@ -51,33 +46,22 @@ class SnifferStage:
                 restore_callback = install_output_interceptor(
                     service,
                     capability,
-                    rewrite_result=partial(self._observe_output, service, capability),
+                    rewrite_result=self._drop_output,
                 )
                 self._restore_callbacks.append(restore_callback)
 
         return AttackStageResult(
             stage_name=self.stage_name,
             status=Status.SUCCESS,
-            reason=f"Installed observers for {len(self.capabilities)} capability handler(s) on {len(services)} service(s).",
+            reason=f"Installed droppers for {len(self.capabilities)} capability handler(s) on {len(services)} service(s).",
         )
 
     def deactivate(self) -> None:
-        """Remove all active observers installed by this stage."""
+        """Remove all active interceptors installed by this stage."""
         while self._restore_callbacks:
             restore_callback = self._restore_callbacks.pop()
             restore_callback()
 
-    def _observe_output(
-        self,
-        service: BehaviorService[Any, Any],
-        capability: Capability,
-        output: Any,
-    ) -> Any:
-        self.observed_outputs.append(
-            ObservedOutput(
-                service=service,
-                capability=capability,
-                output=deepcopy(output),
-            )
-        )
-        return output
+    def _drop_output(self, output: Any) -> tuple[()]:
+        del output
+        return ()

--- a/opencda/core/attack/adversary_framework/stages/replayer/__init__.py
+++ b/opencda/core/attack/adversary_framework/stages/replayer/__init__.py
@@ -1,0 +1,7 @@
+"""Generic replayer stage package."""
+
+from .stage import ReplayerStage
+
+__all__ = [
+    "ReplayerStage",
+]

--- a/opencda/core/attack/adversary_framework/stages/replayer/stage.py
+++ b/opencda/core/attack/adversary_framework/stages/replayer/stage.py
@@ -1,4 +1,4 @@
-"""Replay previously observed service responses."""
+"""Replay previously observed service outputs."""
 
 from __future__ import annotations
 
@@ -15,16 +15,22 @@ from opencda.core.attack.adversary_framework.utils import RestoreCallback, insta
 
 
 @AttackStageRegistry.register
-class ResponseReplayerStage:
-    """Replay the previous output batch produced by `response.submit` handlers."""
+class ReplayerStage:
+    """Replay the previous outputs produced by the configured capability handlers."""
 
-    stage_name = "response_replayer"
-    required_capabilities = (Capability.RESPONSE_SUBMIT,)
-    description = "Replays the previous response-submit output batch for the intercepted service."  # noqa: DC01
+    stage_name = "replayer"
+    supported_capabilities = (
+        Capability.REQUEST_SUBMIT,
+        Capability.RESPONSE_SUBMIT,
+        Capability.COMMAND_SUBMIT,
+    )
+    default_capabilities = (Capability.RESPONSE_SUBMIT,)
+    description = "Replays the previous output observed on the configured capability handlers."  # noqa: DC01
 
-    def __init__(self) -> None:
+    def __init__(self, capabilities: Sequence[Capability]) -> None:
+        self.capabilities = tuple(capabilities)
         self._restore_callbacks: list[RestoreCallback] = []
-        self._previous_outputs_by_service: dict[int, Any] = {}
+        self._previous_outputs_by_binding: dict[tuple[int, Capability], Any] = {}
 
     def execute(self, services: Sequence[BehaviorService[Any, Any]]) -> AttackStageResult:
         self.deactivate()
@@ -33,21 +39,22 @@ class ResponseReplayerStage:
             return AttackStageResult(
                 stage_name=self.stage_name,
                 status=Status.FAIL,
-                reason="ResponseReplayerStage received no target services.",
+                reason="ReplayerStage received no target services.",
             )
 
         for service in services:
-            restore_callback = install_output_interceptor(
-                service,
-                Capability.RESPONSE_SUBMIT,
-                rewrite_result=partial(self._replay_output, service),
-            )
-            self._restore_callbacks.append(restore_callback)
+            for capability in self.capabilities:
+                restore_callback = install_output_interceptor(
+                    service,
+                    capability,
+                    rewrite_result=partial(self._replay_output, service, capability),
+                )
+                self._restore_callbacks.append(restore_callback)
 
         return AttackStageResult(
             stage_name=self.stage_name,
             status=Status.SUCCESS,
-            reason=f"Installed response replayers on {len(services)} service(s).",
+            reason=f"Installed replayers for {len(self.capabilities)} capability handler(s) on {len(services)} service(s).",
         )
 
     def deactivate(self) -> None:
@@ -56,16 +63,17 @@ class ResponseReplayerStage:
             restore_callback = self._restore_callbacks.pop()
             restore_callback()
 
-        self._previous_outputs_by_service.clear()
+        self._previous_outputs_by_binding.clear()
 
     def _replay_output(
         self,
         service: BehaviorService[Any, Any],
+        capability: Capability,
         output: Any,
     ) -> Any:
-        service_key = id(service)
-        previous_output = self._previous_outputs_by_service.get(service_key)
-        self._previous_outputs_by_service[service_key] = deepcopy(output)
+        binding_key = (id(service), capability)
+        previous_output = self._previous_outputs_by_binding.get(binding_key)
+        self._previous_outputs_by_binding[binding_key] = deepcopy(output)
 
         if previous_output is None:
             return output

--- a/opencda/core/attack/adversary_framework/stages/replayer/stage.py
+++ b/opencda/core/attack/adversary_framework/stages/replayer/stage.py
@@ -19,7 +19,9 @@ class ReplayerStage:
 
     stage_name = "replayer"
     supported_capabilities = (
+        Capability.REQUEST_OBSERVE,
         Capability.REQUEST_SUBMIT,
+        Capability.RESPONSE_OBSERVE,
         Capability.RESPONSE_SUBMIT,
         Capability.COMMAND_SUBMIT,
     )

--- a/opencda/core/attack/adversary_framework/stages/replayer/stage.py
+++ b/opencda/core/attack/adversary_framework/stages/replayer/stage.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
-from copy import deepcopy
 from functools import partial
 from typing import Any
 
@@ -11,7 +10,7 @@ from opencda.core.application.behavior.behavior_service_protocol import Behavior
 from opencda.core.application.behavior.capability import Capability
 from opencda.core.attack.adversary_framework.models import AttackStageResult, Status
 from opencda.core.attack.adversary_framework.stage_registry import AttackStageRegistry
-from opencda.core.attack.adversary_framework.utils import RestoreCallback, install_output_interceptor
+from opencda.core.attack.adversary_framework.utils import RestoreCallback, install_output_interceptor, safe_clone
 
 
 @AttackStageRegistry.register
@@ -73,9 +72,9 @@ class ReplayerStage:
     ) -> Any:
         binding_key = (id(service), capability)
         previous_output = self._previous_outputs_by_binding.get(binding_key)
-        self._previous_outputs_by_binding[binding_key] = deepcopy(output)
+        self._previous_outputs_by_binding[binding_key] = safe_clone(output)
 
         if previous_output is None:
             return output
 
-        return deepcopy(previous_output)
+        return safe_clone(previous_output)

--- a/opencda/core/attack/adversary_framework/stages/response_replayer/__init__.py
+++ b/opencda/core/attack/adversary_framework/stages/response_replayer/__init__.py
@@ -1,7 +1,0 @@
-"""Response replayer stage package."""
-
-from .stage import ResponseReplayerStage
-
-__all__ = [
-    "ResponseReplayerStage",
-]

--- a/opencda/core/attack/adversary_framework/stages/sniffer/stage.py
+++ b/opencda/core/attack/adversary_framework/stages/sniffer/stage.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
-from copy import deepcopy
 from functools import partial
 from typing import Any
 
@@ -12,7 +11,7 @@ from opencda.core.application.behavior.capability import Capability
 from opencda.core.attack.adversary_framework.models import AttackStageResult, Status
 from opencda.core.attack.adversary_framework.stage_registry import AttackStageRegistry
 from opencda.core.attack.adversary_framework.stages.sniffer.types import ObservedOutput
-from opencda.core.attack.adversary_framework.utils import RestoreCallback, install_output_interceptor
+from opencda.core.attack.adversary_framework.utils import RestoreCallback, install_output_interceptor, safe_clone
 
 
 @AttackStageRegistry.register
@@ -77,7 +76,7 @@ class SnifferStage:
             ObservedOutput(
                 service=service,
                 capability=capability,
-                output=deepcopy(output),
+                output=safe_clone(output),
             )
         )
         return output

--- a/opencda/core/attack/adversary_framework/stages/sniffer/types.py
+++ b/opencda/core/attack/adversary_framework/stages/sniffer/types.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from typing import Any
 
 from opencda.core.application.behavior.behavior_service_protocol import BehaviorService
+from opencda.core.application.behavior.capability import Capability
 
 
 @dataclass(slots=True)
@@ -11,4 +12,5 @@ class ObservedOutput:
     """Observed output captured from a service capability call."""
 
     service: BehaviorService[Any, Any]
+    capability: Capability
     output: Any

--- a/opencda/core/attack/adversary_framework/stages/spoofer/__init__.py
+++ b/opencda/core/attack/adversary_framework/stages/spoofer/__init__.py
@@ -1,0 +1,7 @@
+"""Generic spoofer stage package."""
+
+from .stage import SpooferStage
+
+__all__ = [
+    "SpooferStage",
+]

--- a/opencda/core/attack/adversary_framework/stages/spoofer/stage.py
+++ b/opencda/core/attack/adversary_framework/stages/spoofer/stage.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from collections.abc import Mapping, MutableMapping, MutableSequence, Sequence
-from copy import deepcopy
 from dataclasses import dataclass, is_dataclass
 from typing import Any
 
@@ -12,7 +11,7 @@ from opencda.core.application.behavior.capability import Capability
 from opencda.core.application.behavior.transport_message import TransportMessage
 from opencda.core.attack.adversary_framework.models import AttackStageResult, Status
 from opencda.core.attack.adversary_framework.stage_registry import AttackStageRegistry
-from opencda.core.attack.adversary_framework.utils import RestoreCallback, install_output_interceptor
+from opencda.core.attack.adversary_framework.utils import RestoreCallback, install_output_interceptor, safe_clone
 
 
 @dataclass(frozen=True, slots=True)
@@ -92,7 +91,7 @@ class SpooferStage:
                 continue
 
             if not has_changes:
-                rewritten_message = deepcopy(message)
+                rewritten_message = safe_clone(message)
                 has_changes = True
 
             current_value = self._resolve_path_value(rewritten_message, rewrite_rule.path)
@@ -195,7 +194,7 @@ class SpooferStage:
     @staticmethod
     def _apply_operation(current_value: Any, rewrite_rule: RewriteRule) -> Any:
         if rewrite_rule.operation == "set":
-            return deepcopy(rewrite_rule.value)
+            return safe_clone(rewrite_rule.value)
         if rewrite_rule.operation == "add":
             return current_value + rewrite_rule.value
         if rewrite_rule.operation == "multiply":

--- a/opencda/core/attack/adversary_framework/stages/spoofer/stage.py
+++ b/opencda/core/attack/adversary_framework/stages/spoofer/stage.py
@@ -128,10 +128,7 @@ class SpooferStage:
             operation = str(raw_rewrite.get("operation", "set"))
             if operation not in cls._supported_operations:
                 supported = ", ".join(sorted(cls._supported_operations))
-                raise ValueError(
-                    f"SpooferStage rewrite #{index} has unsupported operation '{operation}'. "
-                    f"Supported operations: [{supported}]."
-                )
+                raise ValueError(f"SpooferStage rewrite #{index} has unsupported operation '{operation}'. Supported operations: [{supported}].")
 
             if "value" not in raw_rewrite:
                 raise ValueError(f"SpooferStage rewrite #{index} must define 'value'.")

--- a/opencda/core/attack/adversary_framework/stages/spoofer/stage.py
+++ b/opencda/core/attack/adversary_framework/stages/spoofer/stage.py
@@ -1,0 +1,206 @@
+"""Spoof selected fields inside TransportMessage outputs."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, MutableMapping, MutableSequence, Sequence
+from copy import deepcopy
+from dataclasses import dataclass, is_dataclass
+from typing import Any
+
+from opencda.core.application.behavior.behavior_service_protocol import BehaviorService
+from opencda.core.application.behavior.capability import Capability
+from opencda.core.application.behavior.transport_message import TransportMessage
+from opencda.core.attack.adversary_framework.models import AttackStageResult, Status
+from opencda.core.attack.adversary_framework.stage_registry import AttackStageRegistry
+from opencda.core.attack.adversary_framework.utils import RestoreCallback, install_output_interceptor
+
+
+@dataclass(frozen=True, slots=True)
+class RewriteRule:
+    """Single message rewrite rule configured through stage params."""
+
+    path: tuple[str, ...]
+    operation: str
+    value: Any
+
+
+@AttackStageRegistry.register
+class SpooferStage:
+    """Rewrite configured fields on TransportMessage envelopes and payloads."""
+
+    stage_name = "spoofer"
+    supported_capabilities = (
+        Capability.REQUEST_SUBMIT,
+        Capability.RESPONSE_SUBMIT,
+        Capability.COMMAND_SUBMIT,
+    )
+    default_capabilities = (Capability.REQUEST_SUBMIT,)
+    description = "Spoofs TransportMessage envelope or payload fields according to configured rewrite rules."  # noqa: DC01
+    _supported_operations = frozenset({"set", "add", "multiply"})
+
+    def __init__(self, capabilities: Sequence[Capability], params: Mapping[str, Any] | None = None) -> None:
+        self.capabilities = tuple(capabilities)
+        self._restore_callbacks: list[RestoreCallback] = []
+        self._rewrite_rules = self._parse_rewrite_rules(params)
+
+    def execute(self, services: Sequence[BehaviorService[Any, Any]]) -> AttackStageResult:
+        self.deactivate()
+
+        if not services:
+            return AttackStageResult(
+                stage_name=self.stage_name,
+                status=Status.FAIL,
+                reason="SpooferStage received no target services.",
+            )
+
+        for service in services:
+            for capability in self.capabilities:
+                restore_callback = install_output_interceptor(
+                    service,
+                    capability,
+                    rewrite_result=self._spoof_output,
+                )
+                self._restore_callbacks.append(restore_callback)
+
+        return AttackStageResult(
+            stage_name=self.stage_name,
+            status=Status.SUCCESS,
+            reason=f"Installed spoofers for {len(self.capabilities)} capability handler(s) on {len(services)} service(s).",
+        )
+
+    def deactivate(self) -> None:
+        """Remove all active interceptors installed by this stage."""
+        while self._restore_callbacks:
+            restore_callback = self._restore_callbacks.pop()
+            restore_callback()
+
+    def _spoof_output(self, output: Any) -> Any:
+        if isinstance(output, TransportMessage):
+            return self._spoof_message(output)
+        if isinstance(output, tuple):
+            return tuple(self._spoof_output(item) for item in output)
+        if isinstance(output, list):
+            return [self._spoof_output(item) for item in output]
+        return output
+
+    def _spoof_message(self, message: TransportMessage[Any]) -> TransportMessage[Any]:
+        rewritten_message: TransportMessage[Any] = message
+        has_changes = False
+
+        for rewrite_rule in self._rewrite_rules:
+            if not self._path_exists(rewritten_message, rewrite_rule.path):
+                continue
+
+            if not has_changes:
+                rewritten_message = deepcopy(message)
+                has_changes = True
+
+            current_value = self._resolve_path_value(rewritten_message, rewrite_rule.path)
+            spoofed_value = self._apply_operation(current_value, rewrite_rule)
+            self._assign_path_value(rewritten_message, rewrite_rule.path, spoofed_value)
+
+        return rewritten_message
+
+    @classmethod
+    def _parse_rewrite_rules(cls, params: Mapping[str, Any] | None) -> tuple[RewriteRule, ...]:
+        if params is None:
+            raise ValueError("SpooferStage requires 'params.rewrites' configuration.")
+
+        raw_rewrites = params.get("rewrites")
+        if not isinstance(raw_rewrites, Sequence) or isinstance(raw_rewrites, (str, bytes, bytearray)):
+            raise ValueError("SpooferStage requires 'params.rewrites' to be a sequence of mappings.")
+        if not raw_rewrites:
+            raise ValueError("SpooferStage requires at least one rewrite rule in 'params.rewrites'.")
+
+        rewrite_rules: list[RewriteRule] = []
+        for index, raw_rewrite in enumerate(raw_rewrites):
+            if not isinstance(raw_rewrite, Mapping):
+                raise ValueError(f"SpooferStage rewrite #{index} must be a mapping.")
+
+            raw_path = raw_rewrite.get("path")
+            if not isinstance(raw_path, str) or not raw_path:
+                raise ValueError(f"SpooferStage rewrite #{index} must define a non-empty string 'path'.")
+
+            path = tuple(raw_path.split("."))
+            if any(not segment for segment in path):
+                raise ValueError(f"SpooferStage rewrite #{index} has invalid path '{raw_path}'.")
+
+            operation = str(raw_rewrite.get("operation", "set"))
+            if operation not in cls._supported_operations:
+                supported = ", ".join(sorted(cls._supported_operations))
+                raise ValueError(
+                    f"SpooferStage rewrite #{index} has unsupported operation '{operation}'. "
+                    f"Supported operations: [{supported}]."
+                )
+
+            if "value" not in raw_rewrite:
+                raise ValueError(f"SpooferStage rewrite #{index} must define 'value'.")
+
+            rewrite_rules.append(
+                RewriteRule(
+                    path=path,
+                    operation=operation,
+                    value=raw_rewrite["value"],
+                )
+            )
+
+        return tuple(rewrite_rules)
+
+    @staticmethod
+    def _path_exists(root: Any, path: tuple[str, ...]) -> bool:
+        try:
+            SpooferStage._resolve_path_value(root, path)
+        except (AttributeError, IndexError, KeyError, TypeError, ValueError):
+            return False
+        return True
+
+    @staticmethod
+    def _resolve_path_value(root: Any, path: tuple[str, ...]) -> Any:
+        current = root
+        for segment in path:
+            current = SpooferStage._read_child(current, segment)
+        return current
+
+    @staticmethod
+    def _assign_path_value(root: Any, path: tuple[str, ...], value: Any) -> None:
+        parent = root
+        for segment in path[:-1]:
+            parent = SpooferStage._read_child(parent, segment)
+        SpooferStage._write_child(parent, path[-1], value)
+
+    @staticmethod
+    def _read_child(parent: Any, segment: str) -> Any:
+        if isinstance(parent, Mapping):
+            return parent[segment]
+        if SpooferStage._is_sequence_index(segment) and isinstance(parent, Sequence) and not isinstance(parent, (str, bytes, bytearray)):
+            return parent[int(segment)]
+        return getattr(parent, segment)
+
+    @staticmethod
+    def _write_child(parent: Any, segment: str, value: Any) -> None:
+        if isinstance(parent, MutableMapping):
+            parent[segment] = value
+            return
+        if SpooferStage._is_sequence_index(segment):
+            if isinstance(parent, MutableSequence):
+                parent[int(segment)] = value
+                return
+            raise TypeError("SpooferStage does not support indexed writes to immutable sequences.")
+        if is_dataclass(parent):
+            object.__setattr__(parent, segment, value)
+            return
+        setattr(parent, segment, value)
+
+    @staticmethod
+    def _is_sequence_index(segment: str) -> bool:
+        return segment.isdigit()
+
+    @staticmethod
+    def _apply_operation(current_value: Any, rewrite_rule: RewriteRule) -> Any:
+        if rewrite_rule.operation == "set":
+            return deepcopy(rewrite_rule.value)
+        if rewrite_rule.operation == "add":
+            return current_value + rewrite_rule.value
+        if rewrite_rule.operation == "multiply":
+            return current_value * rewrite_rule.value
+        raise ValueError(f"Unsupported rewrite operation '{rewrite_rule.operation}'.")

--- a/opencda/core/attack/adversary_framework/utils.py
+++ b/opencda/core/attack/adversary_framework/utils.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 from collections import deque
 from collections.abc import Callable, Collection, Iterable
-from copy import deepcopy
-from dataclasses import fields, is_dataclass, replace
+from copy import copy, deepcopy
+from dataclasses import fields, is_dataclass
 import logging
 from typing import Any, TypeAlias
 
@@ -38,9 +38,14 @@ def safe_clone(value: Any) -> Any:
         return {safe_clone(key): safe_clone(item) for key, item in value.items()}
     if isinstance(value, deque):
         return deque((safe_clone(item) for item in value), maxlen=value.maxlen)
-    if is_dataclass(value):
-        field_values = {field.name: safe_clone(getattr(value, field.name)) for field in fields(value)}
-        return replace(value, **field_values)
+    if is_dataclass(value) and not isinstance(value, type):
+        try:
+            cloned_value = copy(value)
+            for field in fields(value):
+                object.__setattr__(cloned_value, field.name, safe_clone(getattr(value, field.name)))
+            return cloned_value
+        except Exception:
+            return value
 
     try:
         return deepcopy(value)

--- a/opencda/core/attack/adversary_framework/utils.py
+++ b/opencda/core/attack/adversary_framework/utils.py
@@ -3,19 +3,22 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Collection, Iterable
+import logging
 from typing import Any, TypeAlias
 
 from opencda.core.application.behavior.behavior_service_protocol import BehaviorService
 from opencda.core.application.behavior.capability import Capability
 from opencda.scenario_testing.types import SimulationSnapshot
 
-from .condition_evaluator import resolve_target_node_ids
+from .condition_evaluator import collect_snapshot_values, resolve_target_node_ids
 from .models import TargetSpec
 
 ServiceResolver: TypeAlias = Callable[[str, str], BehaviorService[Any, Any] | None]
 AttackResultRewriter: TypeAlias = Callable[[Any], Any]
 RestoreCallback: TypeAlias = Callable[[], None]
 _MISSING = object()
+
+logger = logging.getLogger("cavise.opencda.opencda.core.attack.adversary_framework.utils")
 
 
 def wrap_method_output(
@@ -97,20 +100,84 @@ def resolve_targets(
     target_spec: TargetSpec | None,
     current_snapshot: SimulationSnapshot,
     service_resolver: ServiceResolver,
+    *,
+    attack_name: str | None = None,
 ) -> tuple[BehaviorService[Any, Any], ...]:
     """Resolve live target services according to a target spec."""
     if target_spec is None:
+        logger.warning(
+            "Attack %r target resolution skipped because no target spec is configured.",
+            attack_name,
+        )
         return ()
 
     if target_spec.kind != "service_state_field":
         raise ValueError(f"Unsupported target resolution kind '{target_spec.kind}'.")
 
+    source_values = collect_snapshot_values(target_spec.source, current_snapshot)
+    if not source_values:
+        logger.warning(
+            "Attack %r target resolution produced no source values: node_type=%r service_type=%r field=%r.",
+            attack_name,
+            target_spec.source.node_type,
+            target_spec.source.service_type,
+            target_spec.source.field,
+        )
+
     target_node_ids = resolve_target_node_ids(target_spec.source, current_snapshot)
+    if not target_node_ids:
+        logger.warning(
+            "Attack %r target resolution normalized to an empty node-id set from source values=%r.",
+            attack_name,
+            source_values,
+        )
+
     target_services: list[BehaviorService[Any, Any]] = []
+    missing_node_ids: list[str] = []
 
     for node_id in sorted(target_node_ids):
         service = service_resolver(node_id, target_spec.resolve_to_service_name)
         if service is not None:
             target_services.append(service)
+        else:
+            missing_node_ids.append(node_id)
+
+    available_node_ids = _collect_available_node_ids(current_snapshot, target_spec.resolve_to_node_type)
+    if missing_node_ids:
+        logger.warning(
+            "Attack %r could not resolve service_type=%r for node_ids=%s. Available %s node_ids in snapshot: %s.",
+            attack_name,
+            target_spec.resolve_to_service_name,
+            missing_node_ids,
+            target_spec.resolve_to_node_type,
+            available_node_ids,
+        )
+
+    if target_services:
+        logger.info(
+            "Attack %r resolved %d target service(s) of type=%r from node_ids=%s.",
+            attack_name,
+            len(target_services),
+            target_spec.resolve_to_service_name,
+            sorted(target_node_ids),
+        )
+    else:
+        logger.warning(
+            "Attack %r resolved zero target services for service_type=%r from node_ids=%s.",
+            attack_name,
+            target_spec.resolve_to_service_name,
+            sorted(target_node_ids),
+        )
 
     return tuple(target_services)
+
+
+def _collect_available_node_ids(
+    snapshot: SimulationSnapshot,
+    node_type: str,
+) -> tuple[str, ...]:
+    if node_type == "vehicle":
+        return tuple(node.node_id for node in snapshot.vehicle_nodes)
+    if node_type == "rsu":
+        return tuple(node.node_id for node in snapshot.rsu_nodes)
+    return tuple(node.node_id for node in snapshot.vehicle_nodes + snapshot.rsu_nodes)

--- a/opencda/core/attack/adversary_framework/utils.py
+++ b/opencda/core/attack/adversary_framework/utils.py
@@ -24,7 +24,7 @@ _MISSING = object()
 logger = logging.getLogger("cavise.opencda.opencda.core.attack.adversary_framework.utils")
 
 # TODO: Consider using a more robust cloning strategy if needed, such as copyreg or custom __deepcopy__ implementations on CARLA types.
-def safe_clone(value: Any) -> Any: 
+def safe_clone(value: Any) -> Any:
     """Clone common Python structures while tolerating opaque runtime objects such as CARLA types."""
     if value is None or isinstance(value, (bool, int, float, str, bytes, bytearray, complex)):
         return value
@@ -139,6 +139,8 @@ def resolve_targets(
 
     if target_spec.kind != "service_state_field":
         raise ValueError(f"Unsupported target resolution kind '{target_spec.kind}'.")
+    if target_spec.selection not in {"all", "first"}:
+        raise ValueError(f"Unsupported target selection '{target_spec.selection}'.")
 
     source_values = collect_snapshot_values(target_spec.source, current_snapshot)
     if not source_values:
@@ -158,10 +160,14 @@ def resolve_targets(
             source_values,
         )
 
+    ordered_target_node_ids = sorted(target_node_ids)
+    if target_spec.selection == "first":
+        ordered_target_node_ids = ordered_target_node_ids[:1]
+
     target_services: list[BehaviorService[Any, Any]] = []
     missing_node_ids: list[str] = []
 
-    for node_id in sorted(target_node_ids):
+    for node_id in ordered_target_node_ids:
         service = service_resolver(node_id, target_spec.resolve_to_service_name)
         if service is not None:
             target_services.append(service)
@@ -185,14 +191,14 @@ def resolve_targets(
             attack_name,
             len(target_services),
             target_spec.resolve_to_service_name,
-            sorted(target_node_ids),
+            ordered_target_node_ids,
         )
     else:
         logger.warning(
             "Attack %r resolved zero target services for service_type=%r from node_ids=%s.",
             attack_name,
             target_spec.resolve_to_service_name,
-            sorted(target_node_ids),
+            ordered_target_node_ids,
         )
 
     return tuple(target_services)

--- a/opencda/core/attack/adversary_framework/utils.py
+++ b/opencda/core/attack/adversary_framework/utils.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections import deque
 from collections.abc import Callable, Collection, Iterable
 from copy import deepcopy
-from dataclasses import fields, is_dataclass
+from dataclasses import fields, is_dataclass, replace
 import logging
 from typing import Any, TypeAlias
 
@@ -16,12 +16,13 @@ from opencda.scenario_testing.types import SimulationSnapshot
 from .condition_evaluator import collect_snapshot_values, resolve_target_node_ids
 from .models import TargetSpec
 
-ServiceResolver: TypeAlias = Callable[[str, str], BehaviorService[Any, Any] | None]
+ServiceResolver: TypeAlias = Callable[[str, str | None], tuple[BehaviorService[Any, Any], ...]]
 AttackResultRewriter: TypeAlias = Callable[[Any], Any]
 RestoreCallback: TypeAlias = Callable[[], None]
 _MISSING = object()
 
 logger = logging.getLogger("cavise.opencda.opencda.core.attack.adversary_framework.utils")
+
 
 # TODO: Consider using a more robust cloning strategy if needed, such as copyreg or custom __deepcopy__ implementations on CARLA types.
 def safe_clone(value: Any) -> Any:
@@ -39,7 +40,7 @@ def safe_clone(value: Any) -> Any:
         return deque((safe_clone(item) for item in value), maxlen=value.maxlen)
     if is_dataclass(value):
         field_values = {field.name: safe_clone(getattr(value, field.name)) for field in fields(value)}
-        return type(value)(**field_values)
+        return replace(value, **field_values)
 
     try:
         return deepcopy(value)
@@ -166,11 +167,12 @@ def resolve_targets(
 
     target_services: list[BehaviorService[Any, Any]] = []
     missing_node_ids: list[str] = []
+    resolved_service_label = target_spec.resolve_to_service_name if target_spec.resolve_to_service_name is not None else "<any>"
 
     for node_id in ordered_target_node_ids:
-        service = service_resolver(node_id, target_spec.resolve_to_service_name)
-        if service is not None:
-            target_services.append(service)
+        services = service_resolver(node_id, target_spec.resolve_to_service_name)
+        if services:
+            target_services.extend(services)
         else:
             missing_node_ids.append(node_id)
 
@@ -179,25 +181,25 @@ def resolve_targets(
         logger.warning(
             "Attack %r could not resolve service_type=%r for node_ids=%s. Available %s node_ids in snapshot: %s.",
             attack_name,
-            target_spec.resolve_to_service_name,
+            resolved_service_label,
             missing_node_ids,
             target_spec.resolve_to_node_type,
             available_node_ids,
         )
 
     if target_services:
-        logger.info(
+        logger.debug(
             "Attack %r resolved %d target service(s) of type=%r from node_ids=%s.",
             attack_name,
             len(target_services),
-            target_spec.resolve_to_service_name,
+            resolved_service_label,
             ordered_target_node_ids,
         )
     else:
         logger.warning(
             "Attack %r resolved zero target services for service_type=%r from node_ids=%s.",
             attack_name,
-            target_spec.resolve_to_service_name,
+            resolved_service_label,
             ordered_target_node_ids,
         )
 

--- a/opencda/core/attack/adversary_framework/utils.py
+++ b/opencda/core/attack/adversary_framework/utils.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+from collections import deque
 from collections.abc import Callable, Collection, Iterable
+from copy import deepcopy
+from dataclasses import fields, is_dataclass
 import logging
 from typing import Any, TypeAlias
 
@@ -19,6 +22,29 @@ RestoreCallback: TypeAlias = Callable[[], None]
 _MISSING = object()
 
 logger = logging.getLogger("cavise.opencda.opencda.core.attack.adversary_framework.utils")
+
+# TODO: Consider using a more robust cloning strategy if needed, such as copyreg or custom __deepcopy__ implementations on CARLA types.
+def safe_clone(value: Any) -> Any: 
+    """Clone common Python structures while tolerating opaque runtime objects such as CARLA types."""
+    if value is None or isinstance(value, (bool, int, float, str, bytes, bytearray, complex)):
+        return value
+
+    if isinstance(value, tuple):
+        return tuple(safe_clone(item) for item in value)
+    if isinstance(value, list):
+        return [safe_clone(item) for item in value]
+    if isinstance(value, dict):
+        return {safe_clone(key): safe_clone(item) for key, item in value.items()}
+    if isinstance(value, deque):
+        return deque((safe_clone(item) for item in value), maxlen=value.maxlen)
+    if is_dataclass(value):
+        field_values = {field.name: safe_clone(getattr(value, field.name)) for field in fields(value)}
+        return type(value)(**field_values)
+
+    try:
+        return deepcopy(value)
+    except Exception:
+        return value
 
 
 def wrap_method_output(

--- a/opencda/core/common/cav_world.py
+++ b/opencda/core/common/cav_world.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib
+import logging
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -10,6 +11,8 @@ if TYPE_CHECKING:
     from opencda.core.application.platooning.platooning_manager import PlatooningManager
     from opencda.core.common.rsu_manager import RSUManager
     from opencda.core.common.vehicle_manager import VehicleManager
+
+logger = logging.getLogger("cavise.opencda.opencda.core.common.cav_world")
 
 
 class CavWorld(object):
@@ -70,6 +73,11 @@ class CavWorld(object):
         """
         self.vehicle_id_set.add(vehicle_manager.vehicle.id)
         self._vehicle_manager_dict.update({vehicle_manager.id: vehicle_manager})
+        logger.info(
+            "Registered vehicle manager node_id=%r with behavior_services=%s.",
+            vehicle_manager.id,
+            [service.service_type for service in vehicle_manager.behavior_services],
+        )
 
     def update_platooning(self, platooning_manager: PlatooningManager) -> None:
         """
@@ -92,6 +100,11 @@ class CavWorld(object):
             The RSU manager class.
         """
         self._rsu_manager_dict.update({rsu_manager.id: rsu_manager})
+        logger.info(
+            "Registered RSU manager node_id=%r with behavior_services=%s.",
+            rsu_manager.id,
+            [service.service_type for service in rsu_manager.behavior_services],
+        )
 
     def update_sumo_vehicles(self, sumo2carla_ids: dict[str, int]) -> None:
         """
@@ -121,19 +134,66 @@ class CavWorld(object):
         """
         Resolve a behavior service instance by node ID and service name.
         """
+        logger.info(
+            "Resolving behavior service node_id=%r service_type=%r. Known vehicle_nodes=%s known_rsu_nodes=%s.",
+            node_id,
+            service_type,
+            sorted(self._vehicle_manager_dict),
+            sorted(self._rsu_manager_dict),
+        )
+
         vehicle_manager = self._vehicle_manager_dict.get(node_id)
         if vehicle_manager is not None:
+            available_vehicle_services = [service.service_type for service in vehicle_manager.behavior_services]
+            logger.info(
+                "Found vehicle manager for node_id=%r with behavior_services=%s.",
+                node_id,
+                available_vehicle_services,
+            )
             for service in vehicle_manager.behavior_services:
                 if service.service_type == service_type:
+                    logger.info(
+                        "Resolved vehicle behavior service node_id=%r service_type=%r.",
+                        node_id,
+                        service_type,
+                    )
                     return service
+            logger.warning(
+                "Vehicle manager node_id=%r does not expose requested service_type=%r. Available services=%s.",
+                node_id,
+                service_type,
+                available_vehicle_services,
+            )
             return None
 
         rsu_manager = self._rsu_manager_dict.get(node_id)
         if rsu_manager is not None:
+            available_rsu_services = [service.service_type for service in rsu_manager.behavior_services]
+            logger.info(
+                "Found RSU manager for node_id=%r with behavior_services=%s.",
+                node_id,
+                available_rsu_services,
+            )
             for service in rsu_manager.behavior_services:
                 if service.service_type == service_type:
+                    logger.info(
+                        "Resolved RSU behavior service node_id=%r service_type=%r.",
+                        node_id,
+                        service_type,
+                    )
                     return service
+            logger.warning(
+                "RSU manager node_id=%r does not expose requested service_type=%r. Available services=%s.",
+                node_id,
+                service_type,
+                available_rsu_services,
+            )
 
+        logger.warning(
+            "Could not resolve behavior service node_id=%r service_type=%r. No matching vehicle or RSU manager found.",
+            node_id,
+            service_type,
+        )
         return None
 
     def get_platoon_dict(self) -> dict[str, PlatooningManager]:

--- a/opencda/core/common/cav_world.py
+++ b/opencda/core/common/cav_world.py
@@ -200,13 +200,6 @@ class CavWorld(object):
         )
         return ()
 
-    def resolve_behavior_service(self, node_id: str, service_type: str) -> BehaviorService[Any, Any] | None:
-        """
-        Resolve a behavior service instance by node ID and service name.
-        """
-        services = self.resolve_behavior_services(node_id, service_type)
-        return services[0] if services else None
-
     def get_platoon_dict(self) -> dict[str, PlatooningManager]:
         """
         Return existing platoons.

--- a/opencda/core/common/cav_world.py
+++ b/opencda/core/common/cav_world.py
@@ -73,7 +73,7 @@ class CavWorld(object):
         """
         self.vehicle_id_set.add(vehicle_manager.vehicle.id)
         self._vehicle_manager_dict.update({vehicle_manager.id: vehicle_manager})
-        logger.info(
+        logger.debug(
             "Registered vehicle manager node_id=%r with behavior_services=%s.",
             vehicle_manager.id,
             [service.service_type for service in vehicle_manager.behavior_services],
@@ -100,7 +100,7 @@ class CavWorld(object):
             The RSU manager class.
         """
         self._rsu_manager_dict.update({rsu_manager.id: rsu_manager})
-        logger.info(
+        logger.debug(
             "Registered RSU manager node_id=%r with behavior_services=%s.",
             rsu_manager.id,
             [service.service_type for service in rsu_manager.behavior_services],
@@ -130,71 +130,82 @@ class CavWorld(object):
         """
         return self._rsu_manager_dict
 
-    def resolve_behavior_service(self, node_id: str, service_type: str) -> BehaviorService[Any, Any] | None:
+    def _get_behavior_services_for_node(self, node_id: str) -> tuple[BehaviorService[Any, Any], ...]:
+        vehicle_manager = self._vehicle_manager_dict.get(node_id)
+        if vehicle_manager is not None:
+            available_vehicle_services = [service.service_type for service in vehicle_manager.behavior_services]
+            logger.debug(
+                "Found vehicle manager for node_id=%r with behavior_services=%s.",
+                node_id,
+                available_vehicle_services,
+            )
+            return tuple(vehicle_manager.behavior_services)
+
+        rsu_manager = self._rsu_manager_dict.get(node_id)
+        if rsu_manager is not None:
+            available_rsu_services = [service.service_type for service in rsu_manager.behavior_services]
+            logger.debug(
+                "Found RSU manager for node_id=%r with behavior_services=%s.",
+                node_id,
+                available_rsu_services,
+            )
+            return tuple(rsu_manager.behavior_services)
+
+        return ()
+
+    def resolve_behavior_services(self, node_id: str, service_type: str | None = None) -> tuple[BehaviorService[Any, Any], ...]:
         """
-        Resolve a behavior service instance by node ID and service name.
+        Resolve behavior service instances by node ID and optional service name.
         """
-        logger.info(
-            "Resolving behavior service node_id=%r service_type=%r. Known vehicle_nodes=%s known_rsu_nodes=%s.",
+        logger.debug(
+            "Resolving behavior services node_id=%r service_type=%r. Known vehicle_nodes=%s known_rsu_nodes=%s.",
             node_id,
             service_type,
             sorted(self._vehicle_manager_dict),
             sorted(self._rsu_manager_dict),
         )
 
-        vehicle_manager = self._vehicle_manager_dict.get(node_id)
-        if vehicle_manager is not None:
-            available_vehicle_services = [service.service_type for service in vehicle_manager.behavior_services]
-            logger.info(
-                "Found vehicle manager for node_id=%r with behavior_services=%s.",
-                node_id,
-                available_vehicle_services,
-            )
-            for service in vehicle_manager.behavior_services:
-                if service.service_type == service_type:
-                    logger.info(
-                        "Resolved vehicle behavior service node_id=%r service_type=%r.",
-                        node_id,
-                        service_type,
-                    )
-                    return service
+        node_services = self._get_behavior_services_for_node(node_id)
+        if not node_services:
             logger.warning(
-                "Vehicle manager node_id=%r does not expose requested service_type=%r. Available services=%s.",
+                "Could not resolve behavior services node_id=%r service_type=%r. No matching vehicle or RSU manager found.",
                 node_id,
                 service_type,
-                available_vehicle_services,
             )
-            return None
+            return ()
 
-        rsu_manager = self._rsu_manager_dict.get(node_id)
-        if rsu_manager is not None:
-            available_rsu_services = [service.service_type for service in rsu_manager.behavior_services]
-            logger.info(
-                "Found RSU manager for node_id=%r with behavior_services=%s.",
+        if service_type is None:
+            logger.debug(
+                "Resolved %d behavior service(s) for node_id=%r without service_type filtering.",
+                len(node_services),
                 node_id,
-                available_rsu_services,
             )
-            for service in rsu_manager.behavior_services:
-                if service.service_type == service_type:
-                    logger.info(
-                        "Resolved RSU behavior service node_id=%r service_type=%r.",
-                        node_id,
-                        service_type,
-                    )
-                    return service
-            logger.warning(
-                "RSU manager node_id=%r does not expose requested service_type=%r. Available services=%s.",
+            return node_services
+
+        matched_services = tuple(service for service in node_services if service.service_type == service_type)
+        if matched_services:
+            logger.debug(
+                "Resolved %d behavior service(s) for node_id=%r service_type=%r.",
+                len(matched_services),
                 node_id,
                 service_type,
-                available_rsu_services,
             )
+            return matched_services
 
         logger.warning(
-            "Could not resolve behavior service node_id=%r service_type=%r. No matching vehicle or RSU manager found.",
+            "Node node_id=%r does not expose requested service_type=%r. Available services=%s.",
             node_id,
             service_type,
+            [service.service_type for service in node_services],
         )
-        return None
+        return ()
+
+    def resolve_behavior_service(self, node_id: str, service_type: str) -> BehaviorService[Any, Any] | None:
+        """
+        Resolve a behavior service instance by node ID and service name.
+        """
+        services = self.resolve_behavior_services(node_id, service_type)
+        return services[0] if services else None
 
     def get_platoon_dict(self) -> dict[str, PlatooningManager]:
         """

--- a/opencda/scenario_testing/scenario.py
+++ b/opencda/scenario_testing/scenario.py
@@ -350,10 +350,8 @@ class Scenario:
             self.attack_results = self.attack_manager.evaluate(
                 self.attacks,
                 self.simulation_snapshot,
-                service_resolver=self._require_cav_world().resolve_behavior_service,
+                service_resolver=self._require_cav_world().resolve_behavior_services,
             )
-            for result in self.attack_results:
-                logger.info("attack=%s status=%s reason=%s", result.attack_name, result.status.value, result.reason)
 
     def capi_loop(self, opt: argparse.Namespace) -> None:
         if self.communication_manager is None:
@@ -441,10 +439,8 @@ class Scenario:
             self.attack_results = self.attack_manager.evaluate(
                 self.attacks,
                 self.simulation_snapshot,
-                service_resolver=self._require_cav_world().resolve_behavior_service,
+                service_resolver=self._require_cav_world().resolve_behavior_services,
             )
-            for result in self.attack_results:
-                logger.info("attack=%s status=%s reason=%s", result.attack_name, result.status.value, result.reason)
 
     def finalize(self, opt: argparse.Namespace) -> None:
         if opt.record:

--- a/opencda/scenario_testing/scenario.py
+++ b/opencda/scenario_testing/scenario.py
@@ -14,7 +14,7 @@ from omegaconf import DictConfig, OmegaConf
 import opencda.scenario_testing.utils.cosim_api as sim_api
 import opencda.scenario_testing.utils.customized_map_api as map_api
 from opencda.core.application.platooning.platooning_manager import PlatooningManager
-from opencda.core.attack.adversary_framework import Attack, AttackManager, AttackResult, AttackSpec
+from opencda.core.attack.adversary_framework import Attack, AttackManager, AttackSpec
 from opencda.core.common.cav_world import CavWorld
 from opencda.core.common.coperception_data_processor import CoperceptionDataProcessor
 from opencda.core.common.rsu_manager import RSUManager
@@ -248,7 +248,6 @@ class Scenario:
             attacks.append(Attack.from_spec(attack_spec))
 
         self.attacks = attacks
-        self.attack_results: tuple[AttackResult, ...] = () # noqa: DC05
 
     def _build_simulation_snapshot(self, tick: int) -> SimulationSnapshot:
         vehicle_nodes = tuple(
@@ -347,7 +346,7 @@ class Scenario:
             self.messages = new_messages
             self.simulation_snapshot = self._build_simulation_snapshot(tick_number)
 
-            self.attack_results = self.attack_manager.evaluate(
+            self.attack_manager.evaluate(
                 self.attacks,
                 self.simulation_snapshot,
                 service_resolver=self._require_cav_world().resolve_behavior_services,
@@ -436,7 +435,7 @@ class Scenario:
                     new_messages.extend(rsu_messages)
 
             self.simulation_snapshot = self._build_simulation_snapshot(tick_number)
-            self.attack_results = self.attack_manager.evaluate(
+            self.attack_manager.evaluate(
                 self.attacks,
                 self.simulation_snapshot,
                 service_resolver=self._require_cav_world().resolve_behavior_services,

--- a/opencda/scenario_testing/scenario.py
+++ b/opencda/scenario_testing/scenario.py
@@ -55,12 +55,6 @@ class Scenario:
             self._abort_simulation("Coperception data processor is required, but it was not initialized.")
         return self.coperception_data_processor
 
-    def _require_cav_world(self) -> CavWorld:
-        cav_world = self.scenario_manager.cav_world
-        if cav_world is None:
-            self._abort_simulation("Scenario manager was initialized without CavWorld; simulation cannot continue.")
-        return cav_world
-
     def __init__(self, opt: argparse.Namespace, scenario_params: DictConfig) -> None:
         self.node_ids: dict[str, dict[int, str]] = {"cav": {}, "rsu": {}, "platoon": {}}
         self.scenario_name = opt.test_scenario
@@ -116,7 +110,7 @@ class Scenario:
                 carla_host=opt.carla_host,
                 carla_timeout=opt.carla_timeout,
             )
-        self.cav_world = self._require_cav_world()
+        self.cav_world = self.scenario_manager.cav_world
 
         if opt.with_capi:
             from opencda.core.common.communication import toolchain
@@ -225,8 +219,7 @@ class Scenario:
         self.scenario_manager.create_custom_actor_manager(application=["single"], map_helper=map_api.spawn_helper_2lanefree, data_dump=opt.record)
         logger.info("created single custom actors")
 
-        cav_world = self._require_cav_world()
-        self.eval_manager = EvaluationManager(cav_world, script_name=self.scenario_name, current_time=scenario_config["current_time"])
+        self.eval_manager = EvaluationManager(self.cav_world, script_name=self.scenario_name, current_time=scenario_config["current_time"])
 
         self.spectator = self.scenario_manager.world.get_spectator()
 
@@ -349,7 +342,7 @@ class Scenario:
             self.attack_manager.evaluate(
                 self.attacks,
                 self.simulation_snapshot,
-                service_resolver=self._require_cav_world().resolve_behavior_services,
+                service_resolver=self.cav_world.resolve_behavior_services,
             )
 
     def capi_loop(self, opt: argparse.Namespace) -> None:
@@ -438,7 +431,7 @@ class Scenario:
             self.attack_manager.evaluate(
                 self.attacks,
                 self.simulation_snapshot,
-                service_resolver=self._require_cav_world().resolve_behavior_services,
+                service_resolver=self.cav_world.resolve_behavior_services,
             )
 
     def finalize(self, opt: argparse.Namespace) -> None:

--- a/opencda/scenario_testing/scenario.py
+++ b/opencda/scenario_testing/scenario.py
@@ -248,7 +248,7 @@ class Scenario:
             attacks.append(Attack.from_spec(attack_spec))
 
         self.attacks = attacks
-        self.attack_results: tuple[AttackResult, ...] = ()
+        self.attack_results: tuple[AttackResult, ...] = () # noqa: DC05
 
     def _build_simulation_snapshot(self, tick: int) -> SimulationSnapshot:
         vehicle_nodes = tuple(

--- a/opencda/scenario_testing/scenario.py
+++ b/opencda/scenario_testing/scenario.py
@@ -55,6 +55,12 @@ class Scenario:
             self._abort_simulation("Coperception data processor is required, but it was not initialized.")
         return self.coperception_data_processor
 
+    def _require_cav_world(self) -> CavWorld:
+        cav_world = self.scenario_manager.cav_world
+        if cav_world is None:
+            self._abort_simulation("Scenario manager was initialized without CavWorld; simulation cannot continue.")
+        return cav_world
+
     def __init__(self, opt: argparse.Namespace, scenario_params: DictConfig) -> None:
         self.node_ids: dict[str, dict[int, str]] = {"cav": {}, "rsu": {}, "platoon": {}}
         self.scenario_name = opt.test_scenario
@@ -110,6 +116,7 @@ class Scenario:
                 carla_host=opt.carla_host,
                 carla_timeout=opt.carla_timeout,
             )
+        self.cav_world = self._require_cav_world()
 
         if opt.with_capi:
             from opencda.core.common.communication import toolchain
@@ -218,9 +225,7 @@ class Scenario:
         self.scenario_manager.create_custom_actor_manager(application=["single"], map_helper=map_api.spawn_helper_2lanefree, data_dump=opt.record)
         logger.info("created single custom actors")
 
-        cav_world = self.scenario_manager.cav_world
-        if cav_world is None:
-            self._abort_simulation("Scenario manager was initialized without CavWorld; simulation cannot continue.")
+        cav_world = self._require_cav_world()
         self.eval_manager = EvaluationManager(cav_world, script_name=self.scenario_name, current_time=scenario_config["current_time"])
 
         self.spectator = self.scenario_manager.world.get_spectator()
@@ -345,7 +350,7 @@ class Scenario:
             self.attack_results = self.attack_manager.evaluate(
                 self.attacks,
                 self.simulation_snapshot,
-                service_resolver=self.cav_world.resolve_behavior_service,
+                service_resolver=self._require_cav_world().resolve_behavior_service,
             )
             for result in self.attack_results:
                 logger.info("attack=%s status=%s reason=%s", result.attack_name, result.status.value, result.reason)
@@ -436,7 +441,7 @@ class Scenario:
             self.attack_results = self.attack_manager.evaluate(
                 self.attacks,
                 self.simulation_snapshot,
-                service_resolver=self.cav_world.resolve_behavior_service,
+                service_resolver=self._require_cav_world().resolve_behavior_service,
             )
             for result in self.attack_results:
                 logger.info("attack=%s status=%s reason=%s", result.attack_name, result.status.value, result.reason)

--- a/opencda/scenario_testing/utils/sim_api.py
+++ b/opencda/scenario_testing/utils/sim_api.py
@@ -231,7 +231,7 @@ class ScenarioManager:
             # normalize probability
             self.bp_class_sample_prob = {k: v / sum(self.bp_class_sample_prob.values()) for k, v in self.bp_class_sample_prob.items()}
 
-        self.cav_world = cav_world
+        self.cav_world = cav_world if cav_world is not None else CavWorld(apply_ml)
         self.carla_map = self.world.get_map()
         self.apply_ml = apply_ml
 
@@ -415,8 +415,6 @@ class ScenarioManager:
         platoon_list: list[PlatooningManager] = []
         platoon_carla_ids: dict[int, Any] = {}
         perception_requirements = perception_requirements or PerceptionRequirements()
-
-        self.cav_world = CavWorld(self.apply_ml)
 
         if self.scenario_params.get("scenario") is None or self.scenario_params["scenario"].get("platoon_list", None) is None:
             logger.info("No platoon was created")

--- a/opencda/scenario_testing/utils/yaml_utils.py
+++ b/opencda/scenario_testing/utils/yaml_utils.py
@@ -9,7 +9,7 @@ from datetime import datetime
 from os import PathLike
 from typing import Any, TypeAlias, cast
 
-import yaml  # type: ignore[import-untyped]
+import yaml
 from omegaconf import OmegaConf
 
 YamlDict: TypeAlias = dict[str, Any]

--- a/test/test_sim_api.py
+++ b/test/test_sim_api.py
@@ -456,9 +456,7 @@ def test_create_platoon_manager_creates_one_platoon_two_members(mocker, minimal_
 
     sm, world, _ = _make_scenario_manager(mocker, params)
     world.tick.reset_mock()
-
-    cav_world_instance = Mock()
-    cav_world_ctor = mocker.patch("opencda.scenario_testing.utils.sim_api.CavWorld", return_value=cav_world_instance)
+    existing_cav_world = sm.cav_world
 
     platoon_manager = Mock(spec_set=["set_lead", "add_member", "set_destination", "update_member_order"])
     platoon_manager.set_lead = Mock()
@@ -483,8 +481,7 @@ def test_create_platoon_manager_creates_one_platoon_two_members(mocker, minimal_
 
     platoons, mapping = sm.create_platoon_manager(map_helper=None)
 
-    cav_world_ctor.assert_called_once_with(False)
-    assert sm.cav_world is cav_world_instance
+    assert sm.cav_world is existing_cav_world
 
     assert platoons == [platoon_manager]
     assert mapping == {101: "platoon-1", 102: "platoon-2"}
@@ -493,7 +490,7 @@ def test_create_platoon_manager_creates_one_platoon_two_members(mocker, minimal_
     assert spawn_custom_actor.call_count == 2
 
     platoon_manager_ctor.assert_called_once()
-    assert platoon_manager_ctor.call_args.args[1] is cav_world_instance
+    assert platoon_manager_ctor.call_args.args[1] is existing_cav_world
 
     assert vehicle_manager_ctor.call_count == 2
     for call_ in vehicle_manager_ctor.call_args_list:
@@ -965,9 +962,7 @@ def test_create_platoon_manager_multiple_platoons_combines_mapping_and_ticks_eac
 
     sm, world, _ = _make_scenario_manager(mocker, params)
     world.tick.reset_mock()
-
-    cav_world_instance = Mock()
-    cav_world_ctor = mocker.patch("opencda.scenario_testing.utils.sim_api.CavWorld", return_value=cav_world_instance)
+    existing_cav_world = sm.cav_world
 
     def _make_platoon_manager_mock():
         pm = Mock(spec_set=["set_lead", "add_member", "set_destination", "update_member_order"])
@@ -1007,8 +1002,7 @@ def test_create_platoon_manager_multiple_platoons_combines_mapping_and_ticks_eac
 
     platoons, mapping = sm.create_platoon_manager(map_helper=None)
 
-    cav_world_ctor.assert_called_once_with(False)
-    assert sm.cav_world is cav_world_instance
+    assert sm.cav_world is existing_cav_world
 
     assert platoons == [pm1, pm2]
     assert mapping == {
@@ -1027,8 +1021,8 @@ def test_create_platoon_manager_multiple_platoons_combines_mapping_and_ticks_eac
         assert call_.kwargs["current_time"] == "t0"
 
     assert platoon_manager_ctor.call_count == 2
-    assert platoon_manager_ctor.call_args_list[0].args[1] is cav_world_instance
-    assert platoon_manager_ctor.call_args_list[1].args[1] is cav_world_instance
+    assert platoon_manager_ctor.call_args_list[0].args[1] is existing_cav_world
+    assert platoon_manager_ctor.call_args_list[1].args[1] is existing_cav_world
 
     pm1.set_lead.assert_called_once_with(vm1)
     pm1.add_member.assert_called_once_with(vm2, leader=False)


### PR DESCRIPTION
## Summary

This PR expands the adversary framework with more reusable attack stages and makes stage capability selection configurable per attack. It also adds default capability fallback and the first generic message spoofing/drop primitives needed to build AIM attack scenarios without hardcoding behavior into individual attacks.

## Related issue

Closes #

## Changes

- Refactored attack stage configuration so each stage declares supported and default capabilities, while attack configs can optionally override the exact capability bindings
- Generalized the replay stage into `replayer` and added new reusable `dropper` and `spoofer` stages for message suppression and TransportMessage field rewriting
- Added stage `params` support in attack specs/runtime so configurable stages like `spoofer` can be driven from YAML attack definitions

## Validation

- [ ] Simulation run
- [x] Manual verification
- [ ] Not applicable

## Checklist

- [ ] Linked the related issue
- [x] Kept the PR focused and reviewable
- [ ] Updated documentation if needed
- [ ] Added or updated validation steps if needed
