### PR TITLE
[AdvCP] Add late fusion removal attack

### DIFF
--- a/opencda/core/attack/advcp/attack_helper.py
+++ b/opencda/core/attack/advcp/attack_helper.py
@@ -193,11 +193,11 @@ class AdvCPAttackHelper:
         memory_data: AdvCPMemoryData | None,
     ) -> tuple[list[str], dict[str, list[npt.NDArray]]]:
         if memory_data is None:
-            raise ValueError("AdvCP late spoofing requires current memory data.")
+            raise ValueError("AdvCP late attack requires current memory data.")
 
         mode = cls.require_config_value(advcp_config, "mode")
         match mode:
-            case "spoofing":
+            case "removal" | "spoofing":
                 pass
             case _:
                 raise NotImplementedError(f"AdvCP mode '{mode}' is not available yet.")

--- a/opencda/core/attack/advcp/late_fusion_attack.py
+++ b/opencda/core/attack/advcp/late_fusion_attack.py
@@ -6,10 +6,13 @@ from typing import Any
 import numpy.typing as npt
 import torch
 from opencda.core.attack.advcp.attack_helper import AdvCPAttackHelper
+from opencda.core.attack.advcp.intermediate_fusion_attack import AdvCoperceptionIntermediateFusionAttack
 from opencda.core.attack.advcp.types import AdvCPAttackResult, AdvCPConfig, AdvCPMemoryData, AdvCPVisualizationContext
 
 
 class AdvCoperceptionLateFusionAttack:
+    REMOVAL_IOU_THRESHOLD = 0.1
+
     @staticmethod
     def run(
         batch_data: Any,
@@ -30,9 +33,7 @@ class AdvCoperceptionLateFusionAttack:
         mode = AdvCPAttackHelper.require_config_value(advcp_config, "mode")
         advcp_context = AdvCPVisualizationContext(mode=mode)
         match mode:
-            case "removal":
-                AdvCoperceptionLateFusionAttack._raise_removal_not_available()
-            case "spoofing":
+            case "removal" | "spoofing":
                 pass
             case _:
                 raise NotImplementedError(f"AdvCP mode '{mode}' is not available for late fusion.")
@@ -75,6 +76,7 @@ class AdvCoperceptionLateFusionAttack:
         pred_box3d_list = []
         pred_box2d_list = []
         pred_fake_list = []
+        removed_target_corners_list: list[torch.Tensor] = []
 
         for cav_id, cav_content in batch_data.items():
             transformation_matrix = cav_content["transformation_matrix"]
@@ -95,13 +97,33 @@ class AdvCoperceptionLateFusionAttack:
 
             cav_attack_boxes = attack_boxes_by_attacker_in_batch.get(cav_id)
             if cav_attack_boxes:
-                injected_box_tensors = [AdvCPAttackHelper.convert_box_for_model(attack_box, dataset).to(device) for attack_box in cav_attack_boxes]
-                stacked_injected_boxes = torch.stack(injected_box_tensors, dim=0)
-                injected_scores = torch.ones((len(cav_attack_boxes),), dtype=scores.dtype, device=device)
-                injected_is_fake = torch.ones((len(cav_attack_boxes),), dtype=torch.bool, device=device)
-                boxes3d = torch.vstack([boxes3d, stacked_injected_boxes])
-                scores = torch.hstack([scores, injected_scores])
-                is_fake = torch.hstack([is_fake, injected_is_fake])
+                target_box_tensors = torch.stack(
+                    [AdvCPAttackHelper.convert_box_for_model(attack_box, dataset).to(device) for attack_box in cav_attack_boxes],
+                    dim=0,
+                )
+
+                match mode:
+                    case "spoofing":
+                        injected_scores = torch.ones((len(cav_attack_boxes),), dtype=scores.dtype, device=device)
+                        injected_is_fake = torch.ones((len(cav_attack_boxes),), dtype=torch.bool, device=device)
+                        boxes3d = torch.vstack([boxes3d, target_box_tensors])
+                        scores = torch.hstack([scores, injected_scores])
+                        is_fake = torch.hstack([is_fake, injected_is_fake])
+                    case "removal":
+                        keep_mask = AdvCoperceptionLateFusionAttack._compute_removal_keep_mask(
+                            boxes3d,
+                            target_box_tensors,
+                            dataset,
+                        )
+                        boxes3d = boxes3d[keep_mask]
+                        scores = scores[keep_mask]
+                        is_fake = is_fake[keep_mask]
+
+                        target_corners = box_utils.boxes_to_corners_3d(
+                            target_box_tensors,
+                            order=dataset.post_processor.params["order"],
+                        )
+                        removed_target_corners_list.append(box_utils.project_box3d(target_corners, transformation_matrix))
 
             if boxes3d.shape[0] == 0:
                 continue
@@ -115,7 +137,15 @@ class AdvCoperceptionLateFusionAttack:
             pred_box3d_list.append(projected_boxes3d)
             pred_fake_list.append(is_fake)
 
+        if mode == "removal" and removed_target_corners_list:
+            advcp_context.removed_box_tensor = torch.vstack(removed_target_corners_list)
+
         if len(pred_box2d_list) == 0 or len(pred_box3d_list) == 0:
+            if mode == "removal":
+                gt_box_tensor = dataset.post_processor.generate_gt_bbx(batch_data)
+                empty_corners = torch.zeros((0, 8, 3), dtype=torch.float32, device=device)
+                empty_score = torch.zeros((0,), dtype=torch.float32, device=device)
+                return empty_corners, empty_score, gt_box_tensor, advcp_context
             raise RuntimeError("AdvCP late spoofing produced no detection result.")
 
         pred_box2d_tensor = torch.vstack(pred_box2d_list)
@@ -141,10 +171,29 @@ class AdvCoperceptionLateFusionAttack:
         pred_is_fake_tensor = pred_is_fake_tensor[mask]
         gt_box_tensor = dataset.post_processor.generate_gt_bbx(batch_data)
 
-        if torch.any(pred_is_fake_tensor):
+        if mode == "spoofing" and torch.any(pred_is_fake_tensor):
             advcp_context.fake_box_tensor = pred_box3d_tensor[pred_is_fake_tensor]  # noqa: DC05
 
         return pred_box3d_tensor, pred_score, gt_box_tensor, advcp_context
+
+    @staticmethod
+    def _compute_removal_keep_mask(
+        boxes3d: torch.Tensor,
+        target_boxes: torch.Tensor,
+        dataset: Any,
+        iou_threshold: float = REMOVAL_IOU_THRESHOLD,
+    ) -> torch.Tensor:
+        if boxes3d.shape[0] == 0:
+            return torch.ones((0,), dtype=torch.bool, device=boxes3d.device)
+
+        boxes_lwh = AdvCoperceptionIntermediateFusionAttack._model_boxes_to_lwh(boxes3d, dataset)
+        targets_lwh = AdvCoperceptionIntermediateFusionAttack._model_boxes_to_lwh(target_boxes, dataset)
+
+        keep_mask = torch.ones((boxes3d.shape[0],), dtype=torch.bool, device=boxes3d.device)
+        for target_lwh in targets_lwh:
+            ious = AdvCoperceptionIntermediateFusionAttack._compute_iou_weights(boxes_lwh, target_lwh)
+            keep_mask = keep_mask & (ious < iou_threshold)
+        return keep_mask
 
     @staticmethod
     def _run_default_prediction(
@@ -170,7 +219,3 @@ class AdvCoperceptionLateFusionAttack:
         memory_data: AdvCPMemoryData | None,
     ) -> tuple[list[str], dict[str, list[npt.NDArray]]]:
         return AdvCPAttackHelper.resolve_spoof_boxes_by_attacker(advcp_config, memory_data)
-
-    @staticmethod
-    def _raise_removal_not_available() -> None:
-        raise NotImplementedError("AdvCP late-fusion removal is not available yet.")

--- a/opencda/core/common/coperception_model_manager.py
+++ b/opencda/core/common/coperception_model_manager.py
@@ -24,6 +24,8 @@ from opencda.metrics_tools.metrics.attack_success_rate import AttackSuccessRateM
 from opencda.metrics_tools.metrics.attacker_benign_visibility_ratio import AttackerBenignVisibilityRatioMetric
 from opencda.metrics_tools.metrics.attacker_target_confidence import AttackerTargetConfidenceMetric
 from opencda.metrics_tools.metrics.ap_at_iou import APAtIoUMetric
+from opencda.metrics_tools.metrics.mean_precision_at_iou import MeanPrecisionAtIoUMetric
+from opencda.metrics_tools.metrics.mean_recall_at_iou import MeanRecallAtIoUMetric
 
 if TYPE_CHECKING:
     from opencood.data_utils.datasets.early_fusion_dataset import EarlyFusionDataset
@@ -505,6 +507,14 @@ class CoperceptionModelManager:
                     "warmup_steps": 0,
                     "global_sort_detections": self.opt.global_sort_detections,
                 },
+                MeanRecallAtIoUMetric.metric_name: {
+                    "warmup_steps": 0,
+                    "global_sort_detections": self.opt.global_sort_detections,
+                },
+                MeanPrecisionAtIoUMetric.metric_name: {
+                    "warmup_steps": 0,
+                    "global_sort_detections": self.opt.global_sort_detections,
+                },
                 AttackSuccessRateMetric.metric_name: {
                     "warmup_steps": 0,
                     "iou_threshold": 0.3,
@@ -524,17 +534,8 @@ class CoperceptionModelManager:
             entity_id="global",
             metric_configs=metric_configs,
         )
-        self.ap_at_iou_metric = self._get_ap_at_iou_metric()
 
         self._init_dataset()
-
-    def _get_ap_at_iou_metric(self) -> APAtIoUMetric | None:
-        metric = self.metrics_collector.get_metric(APAtIoUMetric.metric_name)
-        if metric is None:
-            return None
-        if not isinstance(metric, APAtIoUMetric):
-            raise RuntimeError("Coperception AP at IoU metric is not available.")
-        return metric
 
     def get_metric_collection(self) -> MetricCollection:
         """Return raw cooperative perception metrics for the global evaluation report."""
@@ -798,11 +799,3 @@ class CoperceptionModelManager:
                     visualization_context,
                     0,
                 )
-
-    def final_eval(self):
-        eval_dir = f"simulation_output/coperception/results/{self.opt.test_scenario}_{self.current_time}"
-        os.makedirs(eval_dir, exist_ok=True)
-        if self.ap_at_iou_metric is None:
-            logger.info("Skipping OpenCOOD AP final eval because '%s' metric is not active.", APAtIoUMetric.metric_name)
-            return
-        self.ap_at_iou_metric.save_eval_results(eval_dir, self.opt.global_sort_detections)

--- a/opencda/core/common/test/test_coperception_model_manager.py
+++ b/opencda/core/common/test/test_coperception_model_manager.py
@@ -315,23 +315,6 @@ class TestCoperceptionModelManager:
         assert "Expected exactly 1 batch" in mock_warning.call_args_list[0].args[0]
         assert mock_warning.call_args_list[1].args[0] == "Skipping cooperative perception prediction because the data loader is empty."
 
-    def test_final_eval(self, manager_deps, tmp_path, monkeypatch):
-        monkeypatch.chdir(tmp_path)
-
-        opt = DummyOpt(test_scenario="scen1")
-        manager = CoperceptionModelManager(opt, "2023_01_01")
-
-        manager.final_eval()
-
-        expected_dir = tmp_path / "simulation_output/coperception/results/scen1_2023_01_01"
-        assert expected_dir.is_dir()
-
-        manager_deps["eval_utils"].eval_final_results.assert_called()
-        args = manager_deps["eval_utils"].eval_final_results.call_args[0]
-        # Check path arg
-        assert Path(args[1]).resolve() == expected_dir.resolve()
-        assert args[2] == opt.global_sort_detections
-
 
 class TestCoperceptionVisualizer:
     def test_resolve_visualization_config_merges_defaults_and_overrides(self):

--- a/opencda/metrics_tools/metrics/_opencood_eval.py
+++ b/opencda/metrics_tools/metrics/_opencood_eval.py
@@ -1,0 +1,57 @@
+"""Shared helpers for metrics derived from OpenCOOD's `result_stat` accumulation."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping, Sequence, TypeAlias
+
+ResultStat: TypeAlias = dict[float, dict[str, Any]]
+
+
+def load_eval_utils() -> Any:
+    from opencood.utils import eval_utils
+
+    return eval_utils
+
+
+def create_empty_result_stat(iou_thresholds: Sequence[float]) -> ResultStat:
+    return {float(iou): {"tp": [], "fp": [], "gt": 0, "score": []} for iou in iou_thresholds}
+
+
+def snapshot_result_stat(result_stat: ResultStat) -> ResultStat:
+    """Return a copy with fresh lists, since eval_utils mutates tp/fp in place."""
+    return {
+        iou: {
+            "tp": list(stat["tp"]),
+            "fp": list(stat["fp"]),
+            "gt": stat["gt"],
+            "score": list(stat["score"]),
+        }
+        for iou, stat in result_stat.items()
+    }
+
+
+def accumulate_tp_fp(
+    result_stat: ResultStat,
+    iou_thresholds: Sequence[float],
+    context: Mapping[str, Any],
+    metric_name: str,
+) -> None:
+    gt_box_tensor = context.get("gt_box_tensor")
+    if gt_box_tensor is None:
+        raise ValueError(f"{metric_name} metric requires 'gt_box_tensor' in the update context.")
+
+    pred_box_tensor = context.get("pred_box_tensor")
+    pred_score = context.get("pred_score")
+    eval_utils = load_eval_utils()
+    for iou in iou_thresholds:
+        eval_utils.caluclate_tp_fp(
+            pred_box_tensor,
+            pred_score,
+            gt_box_tensor,
+            result_stat,
+            iou,
+        )
+
+
+def iou_series_name(prefix: str, iou: float) -> str:
+    return f"{prefix}_iou_{str(iou).replace('.', '_')}"

--- a/opencda/metrics_tools/metrics/attack_success_rate.py
+++ b/opencda/metrics_tools/metrics/attack_success_rate.py
@@ -22,134 +22,192 @@ def _load_common_utils() -> Any:
     return common_utils
 
 
+def _find_gt_in_removal_zone(
+    gt_np: npt.NDArray,
+    removal_np: npt.NDArray,
+    common_utils: Any,
+) -> list[int]:
+    """Return indices of GT boxes whose XY centroid lies inside any removal zone polygon."""
+    gt_polygons = list(common_utils.convert_format(gt_np))
+    removal_polygons = list(common_utils.convert_format(removal_np))
+    indices = []
+    for i, gt_poly in enumerate(gt_polygons):
+        centroid = gt_poly.centroid
+        for removal_poly in removal_polygons:
+            if removal_poly.contains(centroid):
+                indices.append(i)
+                break
+    return indices
+
+
+def _deduplicate_boxes(boxes_np: npt.NDArray, iou_threshold: float = 0.9) -> npt.NDArray:
+    """Remove near-duplicate boxes (IoU >= iou_threshold), keeping the first occurrence."""
+    if len(boxes_np) <= 1:
+        return boxes_np
+    try:
+        common_utils = _load_common_utils()
+        polygons = list(common_utils.convert_format(boxes_np))
+    except Exception:
+        return boxes_np
+    keep: list[int] = []
+    for i, poly in enumerate(polygons):
+        for kept_idx in keep:
+            union_area = poly.union(polygons[kept_idx]).area
+            if union_area > 0 and poly.intersection(polygons[kept_idx]).area / union_area >= iou_threshold:
+                break
+        else:
+            keep.append(i)
+    return boxes_np[keep]
+
+
+def _has_iou_match(
+    target_polygon: Any,
+    pred_polygons: list[Any],
+    common_utils: Any,
+    iou_threshold: float,
+) -> bool:
+    if not pred_polygons:
+        return False
+    ious = common_utils.compute_iou(target_polygon, pred_polygons)
+    return len(ious) > 0 and float(np.max(ious)) >= iou_threshold
+
+
 class AttackSuccessRateMetric(BaseMetric):
     """Collect ASR for spoofing and removal attacks."""
 
     metric_name = "attack_success_rate"
-    _SPEC_BY_MODE: ClassVar[dict[str, tuple[str, str]]] = {
-        "removal": ("asr_removal", "removed_box_tensor"),
-        "spoofing": ("asr_spoofing", "fake_box_tensor"),
-    }
+    _SERIES_NAMES: ClassVar[tuple[str, str]] = ("asr_removal", "asr_spoofing")
 
     def __init__(self, warmup_steps: int = 0, iou_threshold: float = 0.3):
         super().__init__(warmup_steps=warmup_steps)
         self.iou_threshold = float(iou_threshold)
-        self._samples: dict[str, list[MetricSample]] = {series_name: [] for series_name, _ in self._SPEC_BY_MODE.values()}
+        self._samples: dict[str, list[MetricSample]] = {name: [] for name in self._SERIES_NAMES}
 
     def _process_context(self, context: Mapping[str, Any]) -> None:
         visualization_context = context.get("visualization_context")
         mode = self._normalize_mode(self._get_context_value(visualization_context, "mode"))
-        spec = self._SPEC_BY_MODE.get(mode)
-        if spec is None:
-            return
-        series_name, target_key = spec
 
-        target_boxes = self._get_context_value(visualization_context, target_key)
-        target_boxes_np = self._to_box_array(target_boxes)
-        if target_boxes_np is None:
-            return
-
-        match_result = self._match_targets(context.get("pred_box_tensor"), target_boxes_np, mode)
-        if match_result is None:
+        if mode == "removal":
+            result = self._compute_removal_result(context, visualization_context)
+            series_name = "asr_removal"
+        elif mode == "spoofing":
+            result = self._compute_spoofing_result(context, visualization_context)
+            series_name = "asr_spoofing"
+        else:
             return
 
-        matched_target_count, target_count = match_result
-        success_rate = matched_target_count / target_count if mode == "spoofing" else (target_count - matched_target_count) / target_count
+        if result is None:
+            return
+
+        matched_count, target_count = result
+        success_rate = matched_count / target_count if mode == "spoofing" else (target_count - matched_count) / target_count
         self._samples[series_name].append(self._make_sample(success_rate))
-        self._log_asr(
-            mode=mode,
-            success_rate=success_rate,
-            matched_target_count=matched_target_count,
-            target_count=target_count,
-        )
+        self._log_asr(mode=mode, success_rate=success_rate, matched_count=matched_count, target_count=target_count)
 
     def get_raw(self) -> tuple[MetricSeries, ...]:
-        return tuple(
-            MetricSeries(
-                name=series_name,
-                samples=tuple(self._samples[series_name]),
-            )
-            for series_name, _ in self._SPEC_BY_MODE.values()
-        )
+        return tuple(MetricSeries(name=name, samples=tuple(self._samples[name])) for name in self._SERIES_NAMES)
 
     @classmethod
     def get_report_spec(cls) -> MetricReportSpec:
         return MetricReportSpec(
             metric_name=cls.metric_name,
             display_name="Attack Success Rate",
-            series_names=tuple(series_name for series_name, _ in cls._SPEC_BY_MODE.values()),
+            series_names=cls._SERIES_NAMES,
             summary_specs=(
-                MetricSummarySpec(
-                    series_name="asr_removal",
-                    display_name="Removal ASR",
-                ),
-                MetricSummarySpec(
-                    series_name="asr_spoofing",
-                    display_name="Spoofing ASR",
-                ),
+                MetricSummarySpec(series_name="asr_removal", display_name="Removal ASR"),
+                MetricSummarySpec(series_name="asr_spoofing", display_name="Spoofing ASR"),
             ),
         )
 
-    def _match_targets(self, pred_box_tensor: Any, target_boxes_np: npt.NDArray[np.float32], mode: str) -> tuple[int, int] | None:
-        try:
-            common_utils = _load_common_utils()
-            target_polygon_list = list(common_utils.convert_format(target_boxes_np))
-        except Exception as error:
-            logger.debug("Unable to convert ASR target boxes to polygons: %s", error)
+    def _compute_removal_result(
+        self,
+        context: Mapping[str, Any],
+        visualization_context: Any,
+    ) -> tuple[int, int] | None:
+        """
+        Targets = GT objects whose centroid lies inside the removal zone.
+        Matched = still detected (IoU with any pred >= threshold).
+        ASR = (target_count - matched_count) / target_count.
+        """
+        removal_np = self._to_box_array(self._get_context_value(visualization_context, "removed_box_tensor"))
+        gt_np = self._to_box_array(context.get("gt_box_tensor"))
+        if removal_np is None or gt_np is None:
             return None
 
-        target_count = len(target_polygon_list)
+        try:
+            common_utils = _load_common_utils()
+            target_indices = _find_gt_in_removal_zone(gt_np, removal_np, common_utils)
+        except Exception as error:
+            logger.debug("Unable to find GT targets in removal zone: %s", error)
+            return None
+
+        target_count = len(target_indices)
         if target_count == 0:
             return None
 
-        pred_boxes_np = self._to_box_array(pred_box_tensor)
-        if pred_boxes_np is None:
+        pred_np = self._to_box_array(context.get("pred_box_tensor"))
+        if pred_np is None:
             return 0, target_count
 
         try:
-            pred_polygon_list = list(common_utils.convert_format(pred_boxes_np))
+            target_polygons = list(common_utils.convert_format(gt_np[target_indices]))
+            pred_polygons = list(common_utils.convert_format(pred_np))
         except Exception as error:
-            logger.debug("Unable to convert ASR predicted boxes to polygons: %s", error)
+            logger.debug("Unable to convert removal boxes to polygons: %s", error)
             return 0, target_count
 
-        matched_target_count = 0
-        for target_polygon in target_polygon_list:
-            if self._target_has_matching_detection(target_polygon, pred_polygon_list, common_utils, mode):
-                matched_target_count += 1
-        return matched_target_count, target_count
+        matched_count = sum(1 for tp in target_polygons if _has_iou_match(tp, pred_polygons, common_utils, self.iou_threshold))
+        return matched_count, target_count
 
-    def _target_has_matching_detection(self, target_polygon: Any, pred_polygon_list: list[Any], common_utils: Any, mode: str) -> bool:
-        if mode == "removal" and self._has_detection_center_inside_target(target_polygon, pred_polygon_list):
-            return True
+    def _compute_spoofing_result(
+        self,
+        context: Mapping[str, Any],
+        visualization_context: Any,
+    ) -> tuple[int, int] | None:
+        """
+        Targets = unique configured spoof boxes (deduplicated fake_box_tensor).
+        Matched = detected in predictions (IoU with any pred >= threshold).
+        ASR = matched_count / target_count.
+        """
+        fake_np = self._to_box_array(self._get_context_value(visualization_context, "fake_box_tensor"))
+        if fake_np is None:
+            return None
 
-        ious = common_utils.compute_iou(target_polygon, pred_polygon_list)
-        return len(ious) > 0 and float(np.max(ious)) >= self.iou_threshold
+        unique_np = _deduplicate_boxes(fake_np)
+
+        try:
+            common_utils = _load_common_utils()
+            target_polygons = list(common_utils.convert_format(unique_np))
+        except Exception as error:
+            logger.debug("Unable to convert spoof boxes to polygons: %s", error)
+            return None
+
+        target_count = len(target_polygons)
+        if target_count == 0:
+            return None
+
+        pred_np = self._to_box_array(context.get("pred_box_tensor"))
+        if pred_np is None:
+            return 0, target_count
+
+        try:
+            pred_polygons = list(common_utils.convert_format(pred_np))
+        except Exception as error:
+            logger.debug("Unable to convert pred boxes to polygons: %s", error)
+            return 0, target_count
+
+        matched_count = sum(1 for tp in target_polygons if _has_iou_match(tp, pred_polygons, common_utils, self.iou_threshold))
+        return matched_count, target_count
 
     @staticmethod
-    def _log_asr(
-        *,
-        mode: str,
-        success_rate: float,
-        matched_target_count: int,
-        target_count: int,
-    ) -> None:
+    def _log_asr(*, mode: str, success_rate: float, matched_count: int, target_count: int) -> None:
         logger.info(
             "AdvCP %s ASR value=%.3f matched_targets=%s/%s",
             mode,
             success_rate,
-            matched_target_count,
+            matched_count,
             target_count,
         )
-
-    @staticmethod
-    def _has_detection_center_inside_target(target_polygon: Any, pred_polygon_list: list[Any]) -> bool:
-        for pred_polygon in pred_polygon_list:
-            try:
-                if target_polygon.covers(pred_polygon.centroid):
-                    return True
-            except AttributeError:
-                return False
-        return False
 
     @staticmethod
     def _get_context_value(context: Any, key: str) -> Any:

--- a/opencda/metrics_tools/metrics/attacker_target_confidence.py
+++ b/opencda/metrics_tools/metrics/attacker_target_confidence.py
@@ -22,150 +22,187 @@ def _load_common_utils() -> Any:
     return common_utils
 
 
+def _find_gt_in_removal_zone(
+    gt_np: npt.NDArray,
+    removal_np: npt.NDArray,
+    common_utils: Any,
+) -> list[int]:
+    """Return indices of GT boxes whose XY centroid lies inside any removal zone polygon."""
+    gt_polygons = list(common_utils.convert_format(gt_np))
+    removal_polygons = list(common_utils.convert_format(removal_np))
+    indices = []
+    for i, gt_poly in enumerate(gt_polygons):
+        centroid = gt_poly.centroid
+        for removal_poly in removal_polygons:
+            if removal_poly.contains(centroid):
+                indices.append(i)
+                break
+    return indices
+
+
+def _deduplicate_boxes(boxes_np: npt.NDArray, iou_threshold: float = 0.9) -> npt.NDArray:
+    """Remove near-duplicate boxes (IoU >= iou_threshold), keeping the first occurrence."""
+    if len(boxes_np) <= 1:
+        return boxes_np
+    try:
+        common_utils = _load_common_utils()
+        polygons = list(common_utils.convert_format(boxes_np))
+    except Exception:
+        return boxes_np
+    keep: list[int] = []
+    for i, poly in enumerate(polygons):
+        for kept_idx in keep:
+            union_area = poly.union(polygons[kept_idx]).area
+            if union_area > 0 and poly.intersection(polygons[kept_idx]).area / union_area >= iou_threshold:
+                break
+        else:
+            keep.append(i)
+    return boxes_np[keep]
+
+
+def _best_score_for_target(
+    target_polygon: Any,
+    pred_polygons: list[Any],
+    pred_scores_np: npt.NDArray,
+    common_utils: Any,
+    iou_threshold: float,
+) -> float:
+    """Return the highest pred score for a detection that overlaps target by >= iou_threshold, or 0."""
+    ious = common_utils.compute_iou(target_polygon, pred_polygons)
+    if len(ious) == 0:
+        return 0.0
+    ious_np = np.asarray(ious, dtype=np.float32)
+    best_idx = int(np.argmax(ious_np))
+    if float(ious_np[best_idx]) < iou_threshold:
+        return 0.0
+    return float(pred_scores_np[best_idx])
+
+
 class AttackerTargetConfidenceMetric(BaseMetric):
     """Mean model confidence on per-tick attacker target boxes (removal and spoofing)."""
 
     metric_name = "attacker_target_confidence"
-    _SPEC_BY_MODE: ClassVar[dict[str, tuple[str, str]]] = {
-        "removal": ("confidence_removal", "removed_box_tensor"),
-        "spoofing": ("confidence_spoofing", "fake_box_tensor"),
-    }
+    _SERIES_NAMES: ClassVar[tuple[str, str]] = ("confidence_removal", "confidence_spoofing")
 
     def __init__(self, warmup_steps: int = 0, iou_threshold: float = 0.3):
         super().__init__(warmup_steps=warmup_steps)
         self.iou_threshold = float(iou_threshold)
-        self._samples: dict[str, list[MetricSample]] = {series_name: [] for series_name, _ in self._SPEC_BY_MODE.values()}
+        self._samples: dict[str, list[MetricSample]] = {name: [] for name in self._SERIES_NAMES}
 
     def _process_context(self, context: Mapping[str, Any]) -> None:
         visualization_context = context.get("visualization_context")
         mode = self._normalize_mode(self._get_context_value(visualization_context, "mode"))
-        spec = self._SPEC_BY_MODE.get(mode)
-        if spec is None:
-            return
-        series_name, target_key = spec
 
-        target_boxes = self._get_context_value(visualization_context, target_key)
-        target_boxes_np = self._to_box_array(target_boxes)
-        if target_boxes_np is None:
-            return
-
-        per_target_confidence = self._collect_per_target_confidence(
-            context.get("pred_box_tensor"),
-            context.get("pred_score"),
-            target_boxes_np,
-            mode,
-        )
-        if per_target_confidence is None:
+        if mode == "removal":
+            per_target = self._collect_removal_confidence(context, visualization_context)
+            series_name = "confidence_removal"
+        elif mode == "spoofing":
+            per_target = self._collect_spoofing_confidence(context, visualization_context)
+            series_name = "confidence_spoofing"
+        else:
             return
 
-        mean_confidence = float(np.mean(per_target_confidence)) if len(per_target_confidence) > 0 else 0.0
+        if per_target is None:
+            return
+
+        mean_confidence = float(np.mean(per_target)) if per_target else 0.0
         self._samples[series_name].append(self._make_sample(mean_confidence))
-        self._log_confidence(
-            mode=mode,
-            mean_confidence=mean_confidence,
-            target_count=len(per_target_confidence),
-        )
+        self._log_confidence(mode=mode, mean_confidence=mean_confidence, target_count=len(per_target))
 
     def get_raw(self) -> tuple[MetricSeries, ...]:
-        return tuple(
-            MetricSeries(
-                name=series_name,
-                samples=tuple(self._samples[series_name]),
-            )
-            for series_name, _ in self._SPEC_BY_MODE.values()
-        )
+        return tuple(MetricSeries(name=name, samples=tuple(self._samples[name])) for name in self._SERIES_NAMES)
 
     @classmethod
     def get_report_spec(cls) -> MetricReportSpec:
         return MetricReportSpec(
             metric_name=cls.metric_name,
             display_name="Attacker Target Confidence",
-            series_names=tuple(series_name for series_name, _ in cls._SPEC_BY_MODE.values()),
+            series_names=cls._SERIES_NAMES,
             summary_specs=(
-                MetricSummarySpec(
-                    series_name="confidence_removal",
-                    display_name="Removal Target Confidence",
-                ),
-                MetricSummarySpec(
-                    series_name="confidence_spoofing",
-                    display_name="Spoofing Target Confidence",
-                ),
+                MetricSummarySpec(series_name="confidence_removal", display_name="Removal Target Confidence"),
+                MetricSummarySpec(series_name="confidence_spoofing", display_name="Spoofing Target Confidence"),
             ),
         )
 
-    def _collect_per_target_confidence(
+    def _collect_removal_confidence(
         self,
-        pred_box_tensor: Any,
-        pred_score: Any,
-        target_boxes_np: npt.NDArray[np.float32],
-        mode: str,
+        context: Mapping[str, Any],
+        visualization_context: Any,
     ) -> list[float] | None:
+        """
+        Targets = GT objects whose centroid lies inside the removal zone.
+        Confidence for each = best pred score with IoU >= threshold, else 0.
+        """
+        removal_np = self._to_box_array(self._get_context_value(visualization_context, "removed_box_tensor"))
+        gt_np = self._to_box_array(context.get("gt_box_tensor"))
+        if removal_np is None or gt_np is None:
+            return None
+
         try:
             common_utils = _load_common_utils()
-            target_polygon_list = list(common_utils.convert_format(target_boxes_np))
+            target_indices = _find_gt_in_removal_zone(gt_np, removal_np, common_utils)
         except Exception as error:
-            logger.debug("Unable to convert target boxes to polygons: %s", error)
+            logger.debug("Unable to find GT targets in removal zone: %s", error)
             return None
 
-        target_count = len(target_polygon_list)
-        if target_count == 0:
+        if not target_indices:
             return None
 
-        pred_scores_np = self._to_score_array(pred_score)
-        pred_boxes_np = self._to_box_array(pred_box_tensor)
-        if pred_boxes_np is None or pred_scores_np is None or pred_boxes_np.shape[0] != pred_scores_np.shape[0]:
-            return [0.0] * target_count
+        pred_scores_np = self._to_score_array(context.get("pred_score"))
+        pred_np = self._to_box_array(context.get("pred_box_tensor"))
+        if pred_np is None or pred_scores_np is None or pred_np.shape[0] != pred_scores_np.shape[0]:
+            return [0.0] * len(target_indices)
 
         try:
-            pred_polygon_list = list(common_utils.convert_format(pred_boxes_np))
+            target_polygons = list(common_utils.convert_format(gt_np[target_indices]))
+            pred_polygons = list(common_utils.convert_format(pred_np))
         except Exception as error:
-            logger.debug("Unable to convert predicted boxes to polygons: %s", error)
-            return [0.0] * target_count
+            logger.debug("Unable to convert removal boxes to polygons: %s", error)
+            return [0.0] * len(target_indices)
 
-        return [
-            self._confidence_for_target(target_polygon, pred_polygon_list, pred_scores_np, common_utils, mode)
-            for target_polygon in target_polygon_list
-        ]
+        return [_best_score_for_target(tp, pred_polygons, pred_scores_np, common_utils, self.iou_threshold) for tp in target_polygons]
 
-    def _confidence_for_target(
+    def _collect_spoofing_confidence(
         self,
-        target_polygon: Any,
-        pred_polygon_list: list[Any],
-        pred_scores_np: npt.NDArray[np.float32],
-        common_utils: Any,
-        mode: str,
-    ) -> float:
-        if mode == "removal":
-            covers_index = self._first_detection_index_inside_target(target_polygon, pred_polygon_list)
-            if covers_index is not None:
-                return float(pred_scores_np[covers_index])
+        context: Mapping[str, Any],
+        visualization_context: Any,
+    ) -> list[float] | None:
+        """
+        Targets = unique configured spoof boxes (deduplicated fake_box_tensor).
+        Confidence for each = best pred score with IoU >= threshold, else 0.
+        """
+        fake_np = self._to_box_array(self._get_context_value(visualization_context, "fake_box_tensor"))
+        if fake_np is None:
+            return None
 
-        ious = common_utils.compute_iou(target_polygon, pred_polygon_list)
-        if len(ious) == 0:
-            return 0.0
-        ious_np = np.asarray(ious, dtype=np.float32)
-        best_index = int(np.argmax(ious_np))
-        if float(ious_np[best_index]) < self.iou_threshold:
-            return 0.0
-        return float(pred_scores_np[best_index])
+        unique_np = _deduplicate_boxes(fake_np)
+
+        pred_scores_np = self._to_score_array(context.get("pred_score"))
+        pred_np = self._to_box_array(context.get("pred_box_tensor"))
+
+        try:
+            common_utils = _load_common_utils()
+            target_polygons = list(common_utils.convert_format(unique_np))
+        except Exception as error:
+            logger.debug("Unable to convert spoof boxes to polygons: %s", error)
+            return None
+
+        if not target_polygons:
+            return None
+
+        if pred_np is None or pred_scores_np is None or pred_np.shape[0] != pred_scores_np.shape[0]:
+            return [0.0] * len(target_polygons)
+
+        try:
+            pred_polygons = list(common_utils.convert_format(pred_np))
+        except Exception as error:
+            logger.debug("Unable to convert pred boxes to polygons: %s", error)
+            return [0.0] * len(target_polygons)
+
+        return [_best_score_for_target(tp, pred_polygons, pred_scores_np, common_utils, self.iou_threshold) for tp in target_polygons]
 
     @staticmethod
-    def _first_detection_index_inside_target(target_polygon: Any, pred_polygon_list: list[Any]) -> int | None:
-        for pred_index, pred_polygon in enumerate(pred_polygon_list):
-            try:
-                if target_polygon.covers(pred_polygon.centroid):
-                    return pred_index
-            except AttributeError:
-                return None
-        return None
-
-    @staticmethod
-    def _log_confidence(
-        *,
-        mode: str,
-        mean_confidence: float,
-        target_count: int,
-    ) -> None:
+    def _log_confidence(*, mode: str, mean_confidence: float, target_count: int) -> None:
         logger.info(
             "AdvCP %s target confidence value=%.3f targets=%s",
             mode,

--- a/opencda/metrics_tools/metrics/mean_precision_at_iou.py
+++ b/opencda/metrics_tools/metrics/mean_precision_at_iou.py
@@ -1,9 +1,9 @@
-"""Average precision at IoU metric for cooperative perception."""
+"""Mean precision (precision-recall curve precision axis) metric at configured IoU thresholds."""
 
 from __future__ import annotations
 
 import logging
-from typing import Any, ClassVar, Mapping
+from typing import Any, ClassVar, Mapping, Sequence
 
 from opencda.metrics_tools.base_metric import BaseMetric
 from opencda.metrics_tools.collection_models import MetricSeries
@@ -18,13 +18,13 @@ from opencda.metrics_tools.metrics._opencood_eval import (
 )
 from opencda.metrics_tools.report_models import MetricReportSpec, MetricSummarySpec
 
-logger = logging.getLogger("cavise.opencda.opencda.metrics_tools.metrics.ap_at_iou")
+logger = logging.getLogger("cavise.opencda.opencda.metrics_tools.metrics.mean_precision_at_iou")
 
 
-class APAtIoUMetric(BaseMetric):
-    """Collect detection stats and report AP at configured IoU thresholds."""
+class MeanPrecisionAtIoUMetric(BaseMetric):
+    """Report the mean-precision axis of the precision-recall curve at configured IoU thresholds."""
 
-    metric_name = "ap_at_iou"
+    metric_name = "mean_precision_at_iou"
     iou_thresholds: ClassVar[tuple[float, ...]] = (0.3, 0.5, 0.7)
 
     def __init__(
@@ -38,7 +38,6 @@ class APAtIoUMetric(BaseMetric):
 
     def _process_context(self, context: Mapping[str, Any]) -> None:
         accumulate_tp_fp(self.result_stat, self.iou_thresholds, context, self.metric_name)
-        self._log_ap_at_iou()
 
     def get_raw(self) -> tuple[MetricSeries, ...]:
         if self.steps_count <= self.warmup_steps:
@@ -47,41 +46,30 @@ class APAtIoUMetric(BaseMetric):
         return tuple(
             MetricSeries(
                 name=self._series_name(iou),
-                samples=(
-                    MetricSample(
-                        tick=self.steps_count,
-                        value=self.calculate_ap(iou),
-                    ),
-                ),
+                samples=tuple(MetricSample(tick=index, value=float(value)) for index, value in enumerate(self._calculate_mpre(iou))),
             )
             for iou in self.iou_thresholds
         )
 
-    def calculate_ap(self, iou: float, global_sort_detections: bool | None = None) -> float:
+    def _calculate_mpre(self, iou: float) -> Sequence[float]:
         eval_utils = load_eval_utils()
-        ap, _, _ = eval_utils.calculate_ap(
+        _, _, mpre = eval_utils.calculate_ap(
             snapshot_result_stat(self.result_stat),
             iou,
-            self.global_sort_detections if global_sort_detections is None else global_sort_detections,
+            self.global_sort_detections,
         )
-        return float(ap)
-
-    def _log_ap_at_iou(self) -> None:
-        ap_parts = []
-        for iou in self.iou_thresholds:
-            ap_parts.append(f"AP@IoU {iou:.1f}={self.calculate_ap(iou):.3f}")
-        logger.info("Cooperative perception %s", ", ".join(ap_parts))
+        return mpre
 
     @classmethod
     def get_report_spec(cls) -> MetricReportSpec:
         return MetricReportSpec(
             metric_name=cls.metric_name,
-            display_name="Average Precision at IoU",
+            display_name="Mean Precision at IoU",
             series_names=tuple(cls._series_name(iou) for iou in cls.iou_thresholds),
             summary_specs=tuple(
                 MetricSummarySpec(
                     series_name=cls._series_name(iou),
-                    display_name=f"AP at IoU {iou:.1f}",
+                    display_name=f"Mean Precision at IoU {iou:.1f}",
                 )
                 for iou in cls.iou_thresholds
             ),
@@ -89,4 +77,4 @@ class APAtIoUMetric(BaseMetric):
 
     @staticmethod
     def _series_name(iou: float) -> str:
-        return iou_series_name("ap", iou)
+        return iou_series_name("mpre", iou)

--- a/opencda/metrics_tools/metrics/mean_recall_at_iou.py
+++ b/opencda/metrics_tools/metrics/mean_recall_at_iou.py
@@ -1,9 +1,9 @@
-"""Average precision at IoU metric for cooperative perception."""
+"""Mean recall (precision-recall curve recall axis) metric at configured IoU thresholds."""
 
 from __future__ import annotations
 
 import logging
-from typing import Any, ClassVar, Mapping
+from typing import Any, ClassVar, Mapping, Sequence
 
 from opencda.metrics_tools.base_metric import BaseMetric
 from opencda.metrics_tools.collection_models import MetricSeries
@@ -18,13 +18,13 @@ from opencda.metrics_tools.metrics._opencood_eval import (
 )
 from opencda.metrics_tools.report_models import MetricReportSpec, MetricSummarySpec
 
-logger = logging.getLogger("cavise.opencda.opencda.metrics_tools.metrics.ap_at_iou")
+logger = logging.getLogger("cavise.opencda.opencda.metrics_tools.metrics.mean_recall_at_iou")
 
 
-class APAtIoUMetric(BaseMetric):
-    """Collect detection stats and report AP at configured IoU thresholds."""
+class MeanRecallAtIoUMetric(BaseMetric):
+    """Report the mean-recall axis of the precision-recall curve at configured IoU thresholds."""
 
-    metric_name = "ap_at_iou"
+    metric_name = "mean_recall_at_iou"
     iou_thresholds: ClassVar[tuple[float, ...]] = (0.3, 0.5, 0.7)
 
     def __init__(
@@ -38,7 +38,6 @@ class APAtIoUMetric(BaseMetric):
 
     def _process_context(self, context: Mapping[str, Any]) -> None:
         accumulate_tp_fp(self.result_stat, self.iou_thresholds, context, self.metric_name)
-        self._log_ap_at_iou()
 
     def get_raw(self) -> tuple[MetricSeries, ...]:
         if self.steps_count <= self.warmup_steps:
@@ -47,41 +46,30 @@ class APAtIoUMetric(BaseMetric):
         return tuple(
             MetricSeries(
                 name=self._series_name(iou),
-                samples=(
-                    MetricSample(
-                        tick=self.steps_count,
-                        value=self.calculate_ap(iou),
-                    ),
-                ),
+                samples=tuple(MetricSample(tick=index, value=float(value)) for index, value in enumerate(self._calculate_mrec(iou))),
             )
             for iou in self.iou_thresholds
         )
 
-    def calculate_ap(self, iou: float, global_sort_detections: bool | None = None) -> float:
+    def _calculate_mrec(self, iou: float) -> Sequence[float]:
         eval_utils = load_eval_utils()
-        ap, _, _ = eval_utils.calculate_ap(
+        _, mrec, _ = eval_utils.calculate_ap(
             snapshot_result_stat(self.result_stat),
             iou,
-            self.global_sort_detections if global_sort_detections is None else global_sort_detections,
+            self.global_sort_detections,
         )
-        return float(ap)
-
-    def _log_ap_at_iou(self) -> None:
-        ap_parts = []
-        for iou in self.iou_thresholds:
-            ap_parts.append(f"AP@IoU {iou:.1f}={self.calculate_ap(iou):.3f}")
-        logger.info("Cooperative perception %s", ", ".join(ap_parts))
+        return mrec
 
     @classmethod
     def get_report_spec(cls) -> MetricReportSpec:
         return MetricReportSpec(
             metric_name=cls.metric_name,
-            display_name="Average Precision at IoU",
+            display_name="Mean Recall at IoU",
             series_names=tuple(cls._series_name(iou) for iou in cls.iou_thresholds),
             summary_specs=tuple(
                 MetricSummarySpec(
                     series_name=cls._series_name(iou),
-                    display_name=f"AP at IoU {iou:.1f}",
+                    display_name=f"Mean Recall at IoU {iou:.1f}",
                 )
                 for iou in cls.iou_thresholds
             ),
@@ -89,4 +77,4 @@ class APAtIoUMetric(BaseMetric):
 
     @staticmethod
     def _series_name(iou: float) -> str:
-        return iou_series_name("ap", iou)
+        return iou_series_name("mrec", iou)

--- a/opencda/metrics_tools/test/test_attack_success_rate.py
+++ b/opencda/metrics_tools/test/test_attack_success_rate.py
@@ -11,8 +11,17 @@ class DummyPolygon:
     def centroid(self):
         return self
 
-    def covers(self, _):
+    def contains(self, _):
         return True
+
+
+class OutsideZonePolygon:
+    @property
+    def centroid(self):
+        return self
+
+    def contains(self, _):
+        return False
 
 
 class DummyCommonUtils:
@@ -25,29 +34,48 @@ class DummyCommonUtils:
         return np.ones(len(pred_polygon_list), dtype=np.float32)
 
 
-class AlternatingCoverPolygon:
-    _cover_results = [True, False, False]
-
-    def __init__(self):
-        self.cover_result = self._cover_results.pop(0)
-
-    @property
-    def centroid(self):
-        return self
-
-    def covers(self, _):
-        return self.cover_result
+class _DummyArea:
+    def __init__(self, area):
+        self.area = area
 
 
-class PartialRemovalCommonUtils:
+class OverlappingPolygon(DummyPolygon):
+    """Polygon with full overlap — used to test deduplication (IoU=1.0 with any other polygon)."""
+
+    def union(self, _):
+        return _DummyArea(1.0)
+
+    def intersection(self, _):
+        return _DummyArea(1.0)
+
+
+class DeduplicatingDummyCommonUtils:
     @staticmethod
     def convert_format(boxes):
-        AlternatingCoverPolygon._cover_results = [True, False, False]
-        return [AlternatingCoverPolygon() for _ in boxes]
+        return [OverlappingPolygon() for _ in boxes]
 
     @staticmethod
     def compute_iou(_, pred_polygon_list):
-        return np.zeros(len(pred_polygon_list), dtype=np.float32)
+        return np.ones(len(pred_polygon_list), dtype=np.float32)
+
+
+def _make_first_hit_utils():
+    """compute_iou returns ones for the first call only (first GT target still detected)."""
+    call_count = [0]
+
+    class FirstHitCommonUtils:
+        @staticmethod
+        def convert_format(boxes):
+            return [DummyPolygon() for _ in boxes]
+
+        @staticmethod
+        def compute_iou(_, pred_list):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                return np.ones(len(pred_list), dtype=np.float32)
+            return np.zeros(len(pred_list), dtype=np.float32)
+
+    return FirstHitCommonUtils
 
 
 def _target_box():
@@ -72,6 +100,7 @@ def test_removal_asr_succeeds_when_target_is_not_detected(monkeypatch):
     metric.update(
         {
             "pred_box_tensor": None,
+            "gt_box_tensor": _target_box(),
             "visualization_context": {
                 "mode": "removal",
                 "removed_box_tensor": _target_box(),
@@ -90,6 +119,7 @@ def test_removal_asr_fails_when_target_is_still_detected(monkeypatch):
     metric.update(
         {
             "pred_box_tensor": _target_box(),
+            "gt_box_tensor": _target_box(),
             "visualization_context": SimpleNamespace(
                 mode="removal",
                 removed_box_tensor=_target_box(),
@@ -100,20 +130,49 @@ def test_removal_asr_fails_when_target_is_still_detected(monkeypatch):
     assert _series_values(metric, "asr_removal") == [0.0]
 
 
+def test_removal_asr_skips_when_no_gt_in_removal_zone(monkeypatch):
+    class EmptyZoneUtils:
+        @staticmethod
+        def convert_format(boxes):
+            return [OutsideZonePolygon() for _ in boxes]
+
+        @staticmethod
+        def compute_iou(_, pred_list):
+            return np.zeros(len(pred_list), dtype=np.float32)
+
+    monkeypatch.setattr(attack_success_rate, "_load_common_utils", lambda: EmptyZoneUtils)
+    metric = AttackSuccessRateMetric()
+
+    metric.update(
+        {
+            "pred_box_tensor": _target_box(),
+            "gt_box_tensor": _target_box(),
+            "visualization_context": {
+                "mode": "removal",
+                "removed_box_tensor": _target_box(),
+            },
+        }
+    )
+
+    assert _series_values(metric, "asr_removal") == []
+
+
 def test_removal_asr_reports_fraction_of_removed_targets(monkeypatch):
-    monkeypatch.setattr(attack_success_rate, "_load_common_utils", lambda: PartialRemovalCommonUtils)
+    monkeypatch.setattr(attack_success_rate, "_load_common_utils", lambda: _make_first_hit_utils())
     metric = AttackSuccessRateMetric(iou_threshold=0.3)
 
     metric.update(
         {
             "pred_box_tensor": _target_box(),
+            "gt_box_tensor": _target_boxes(3),
             "visualization_context": {
                 "mode": "removal",
-                "removed_box_tensor": _target_boxes(3),
+                "removed_box_tensor": _target_box(),
             },
         }
     )
 
+    # 1 GT target still detected, 2 removed → ASR = 2/3
     assert _series_values(metric, "asr_removal") == [2 / 3]
 
 
@@ -132,6 +191,26 @@ def test_spoofing_asr_succeeds_when_fake_target_is_detected(monkeypatch):
     )
 
     assert _series_values(metric, "asr_spoofing") == [1.0]
+
+
+def test_spoofing_asr_deduplicates_identical_fake_boxes(monkeypatch):
+    """5 identical attacker boxes (N attackers, same target) → 1 unique target after dedup."""
+    monkeypatch.setattr(attack_success_rate, "_load_common_utils", lambda: DeduplicatingDummyCommonUtils)
+    metric = AttackSuccessRateMetric(iou_threshold=0.3)
+
+    metric.update(
+        {
+            "pred_box_tensor": _target_box(),
+            "visualization_context": {
+                "mode": "spoofing",
+                "fake_box_tensor": _target_boxes(5),
+            },
+        }
+    )
+
+    values = _series_values(metric, "asr_spoofing")
+    assert len(values) == 1
+    assert values[0] == 1.0
 
 
 def test_asr_skips_frames_without_attack_target():

--- a/opencda/metrics_tools/test/test_attack_success_rate.py
+++ b/opencda/metrics_tools/test/test_attack_success_rate.py
@@ -158,7 +158,7 @@ def test_removal_asr_skips_when_no_gt_in_removal_zone(monkeypatch):
 
 
 def test_removal_asr_reports_fraction_of_removed_targets(monkeypatch):
-    monkeypatch.setattr(attack_success_rate, "_load_common_utils", lambda: _make_first_hit_utils())
+    monkeypatch.setattr(attack_success_rate, "_load_common_utils", _make_first_hit_utils)
     metric = AttackSuccessRateMetric(iou_threshold=0.3)
 
     metric.update(

--- a/opencda/metrics_tools/test/test_attacker_target_confidence.py
+++ b/opencda/metrics_tools/test/test_attacker_target_confidence.py
@@ -111,7 +111,7 @@ def test_removal_confidence_uses_iou_match_for_score(monkeypatch):
 
 
 def test_removal_confidence_averages_per_target(monkeypatch):
-    monkeypatch.setattr(attacker_target_confidence, "_load_common_utils", lambda: _make_first_hit_utils())
+    monkeypatch.setattr(attacker_target_confidence, "_load_common_utils", _make_first_hit_utils)
     metric = AttackerTargetConfidenceMetric(iou_threshold=0.3)
 
     metric.update(

--- a/opencda/metrics_tools/test/test_attacker_target_confidence.py
+++ b/opencda/metrics_tools/test/test_attacker_target_confidence.py
@@ -6,28 +6,19 @@ from opencda.metrics_tools.metrics import attacker_target_confidence
 from opencda.metrics_tools.metrics.attacker_target_confidence import AttackerTargetConfidenceMetric
 
 
-class CoveringPolygon:
+class DummyPolygon:
     @property
     def centroid(self):
         return self
 
-    def covers(self, _):
+    def contains(self, _):
         return True
-
-
-class NonCoveringPolygon:
-    @property
-    def centroid(self):
-        return self
-
-    def covers(self, _):
-        return False
 
 
 class HighIoUCommonUtils:
     @staticmethod
     def convert_format(boxes):
-        return [NonCoveringPolygon() for _ in boxes]
+        return [DummyPolygon() for _ in boxes]
 
     @staticmethod
     def compute_iou(_, pred_polygon_list):
@@ -37,24 +28,30 @@ class HighIoUCommonUtils:
 class LowIoUCommonUtils:
     @staticmethod
     def convert_format(boxes):
-        return [NonCoveringPolygon() for _ in boxes]
+        return [DummyPolygon() for _ in boxes]
 
     @staticmethod
     def compute_iou(_, pred_polygon_list):
         return np.zeros(len(pred_polygon_list), dtype=np.float32)
 
 
-class CoverFirstPredCommonUtils:
-    @staticmethod
-    def convert_format(boxes):
-        polygons: list = []
-        for index, _ in enumerate(boxes):
-            polygons.append(CoveringPolygon() if index == 0 else NonCoveringPolygon())
-        return polygons
+def _make_first_hit_utils():
+    """compute_iou returns ones for the first call only (first GT target still detected)."""
+    call_count = [0]
 
-    @staticmethod
-    def compute_iou(_, pred_polygon_list):
-        return np.zeros(len(pred_polygon_list), dtype=np.float32)
+    class FirstHitCommonUtils:
+        @staticmethod
+        def convert_format(boxes):
+            return [DummyPolygon() for _ in boxes]
+
+        @staticmethod
+        def compute_iou(_, pred_list):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                return np.ones(len(pred_list), dtype=np.float32)
+            return np.zeros(len(pred_list), dtype=np.float32)
+
+    return FirstHitCommonUtils
 
 
 def _target_box():
@@ -80,6 +77,7 @@ def test_removal_confidence_zero_when_target_is_not_detected(monkeypatch):
         {
             "pred_box_tensor": None,
             "pred_score": None,
+            "gt_box_tensor": _target_box(),
             "visualization_context": {
                 "mode": "removal",
                 "removed_box_tensor": _target_box(),
@@ -91,14 +89,15 @@ def test_removal_confidence_zero_when_target_is_not_detected(monkeypatch):
     assert _series_values(metric, "confidence_spoofing") == []
 
 
-def test_removal_confidence_uses_pred_score_of_centroid_match(monkeypatch):
-    monkeypatch.setattr(attacker_target_confidence, "_load_common_utils", lambda: CoverFirstPredCommonUtils)
+def test_removal_confidence_uses_iou_match_for_score(monkeypatch):
+    monkeypatch.setattr(attacker_target_confidence, "_load_common_utils", lambda: HighIoUCommonUtils)
     metric = AttackerTargetConfidenceMetric(iou_threshold=0.3)
 
     metric.update(
         {
             "pred_box_tensor": _target_boxes(3),
             "pred_score": np.array([0.8, 0.5, 0.4], dtype=np.float32),
+            "gt_box_tensor": _target_box(),
             "visualization_context": SimpleNamespace(
                 mode="removal",
                 removed_box_tensor=_target_box(),
@@ -106,24 +105,28 @@ def test_removal_confidence_uses_pred_score_of_centroid_match(monkeypatch):
         }
     )
 
-    assert _series_values(metric, "confidence_removal") == [0.800000011920929]
+    values = _series_values(metric, "confidence_removal")
+    assert len(values) == 1
+    assert abs(values[0] - 0.8) < 1e-5
 
 
 def test_removal_confidence_averages_per_target(monkeypatch):
-    monkeypatch.setattr(attacker_target_confidence, "_load_common_utils", lambda: CoverFirstPredCommonUtils)
+    monkeypatch.setattr(attacker_target_confidence, "_load_common_utils", lambda: _make_first_hit_utils())
     metric = AttackerTargetConfidenceMetric(iou_threshold=0.3)
 
     metric.update(
         {
             "pred_box_tensor": _target_boxes(3),
             "pred_score": np.array([0.6, 0.0, 0.0], dtype=np.float32),
+            "gt_box_tensor": _target_boxes(3),
             "visualization_context": {
                 "mode": "removal",
-                "removed_box_tensor": _target_boxes(3),
+                "removed_box_tensor": _target_box(),
             },
         }
     )
 
+    # first GT target: pred[0] best IoU match → score 0.6; others: no match → 0.0
     values = _series_values(metric, "confidence_removal")
     assert len(values) == 1
     assert abs(values[0] - 0.6 / 3) < 1e-5

--- a/opencda/scenario_testing/scenario.py
+++ b/opencda/scenario_testing/scenario.py
@@ -450,9 +450,6 @@ class Scenario:
             self.eval_manager.evaluate(coperception_model_manager=self.coperception_model_manager)
             logger.info("finalizing: evaluating results")
 
-        if self.coperception_model_manager is not None:
-            self.coperception_model_manager.final_eval()
-
         if self.single_cav_list is not None:
             logger.info(f"finalizing: destroying {len(self.single_cav_list)} single cavs")
             for v in self.single_cav_list:


### PR DESCRIPTION
## Summary

This PR completes AdvCP late-fusion removal attack, replaces the legacy `eval.yaml` dump with first-class metrics for mean precision and mean recall, and fixes the semantic correctness of ASR and confidence metrics.

## Changes
- Added late-fusion AdvCP removal attack: per-attacker IoU-based filtering of predicted boxes against configured target boxes, with multi-attacker support inherited from the existing late-fusion per-CAV loop.
- Reused intermediate fusion's existing IoU machinery (`_compute_iou_weights`, `_model_boxes_to_lwh`) instead of duplicating the oriented-box IoU implementation.
- Late-fusion empty-result edge case (all detections removed) now returns empty tensors instead of raising `RuntimeError`; spoofing keeps its prior raise behavior.
- Unblocked `removal` mode in `AdvCPAttackHelper.resolve_spoof_boxes_by_attacker` (previously rejected with `NotImplementedError`).
- Removed visualization context now populates `removed_box_tensor` with target-box corners projected to ego frame via the attacker's `transformation_matrix`.
- Added `MeanRecallAtIoUMetric` and `MeanPrecisionAtIoUMetric`, each emitting precision-recall curve points as samples (tick = curve index) at IoU thresholds 0.3, 0.5, 0.7.
- Extracted shared OpenCOOD `result_stat` helpers (`accumulate_tp_fp`, `create_empty_result_stat`, `snapshot_result_stat`, `load_eval_utils`, `iou_series_name`) into `metrics/_opencood_eval.py`; refactored `APAtIoUMetric` to use them.
- Wired the new metrics into `CoperceptionModelManager.__init__` default configs so they are active alongside `APAtIoUMetric`.
- Removed `CoperceptionModelManager.final_eval()`, `_get_ap_at_iou_metric()`, and the `ap_at_iou_metric` field — mrec/mpre/ap now flow through the standard metrics framework into `EvaluationManager.evaluate(...)` instead of being dumped to `simulation_output/coperception/results/.../eval.yaml`.
- Removed the `final_eval()` invocation from `scenario.py` finalize hook.
- Removed `APAtIoUMetric.save_eval_results()` (no longer used).
- Fixed `AttackSuccessRateMetric` and `AttackerTargetConfidenceMetric` target semantics:
  - **Removal**: targets are now GT objects whose XY centroid falls inside the removal zone polygon (not the removal box itself). Attack success = GT object is no longer detected (IoU with any pred < threshold). This correctly handles N attackers targeting the same zone — target count is determined by the scene geometry, not the number of attackers.
  - **Spoofing**: `fake_box_tensor` is deduplicated by IoU ≥ 0.9 before counting targets, so N attackers injecting the same spoof box count as 1 unique target instead of N.
- Updated unit tests: dropped `test_final_eval`; added `test_removal_asr_skips_when_no_gt_in_removal_zone` and `test_spoofing_asr_deduplicates_identical_fake_boxes`; updated existing removal tests to supply `gt_box_tensor` and reflect GT-based target semantics.

## Validation
- [x] Unit tests
- [x] Lint (mypy, deadcode)

## Checklist
- [x] Kept the PR focused and reviewable
- [x] Added or updated validation steps if needed

---

## AdvCP Integration Status

### Attacks implementation
#### Spoofing
- [x] Early
- [x] Intermediate
- [x] Late
#### Removal
- [x] Early
- [x] Intermediate
- [x] Late

### Multiple attackers
#### Spoofing
- [x] Early
- [x] Intermediate
- [x] Late
#### Removal
- [x] Early
- [x] Intermediate
- [x] Late

### Defense
- [ ] CAD

### Scenarios
- [ ] Create scenarios

### Documentation
#### Spoofing
- [ ] Early
- [ ] Intermediate
- [ ] Late
#### Removal
- [ ] Early
- [ ] Intermediate
- [ ] Late
#### Defense
- [ ] CAD
