### PR TITLE
[AIM] Remove CARLA objects from services and improve trajectory output

### DIFF
--- a/opencda/core/application/behavior/services/aim_client/service.py
+++ b/opencda/core/application/behavior/services/aim_client/service.py
@@ -9,7 +9,6 @@ from collections.abc import Sequence
 from typing import TYPE_CHECKING, cast
 
 import traci
-import carla
 
 from opencda.core.application.behavior.capability import Capability, CapabilityBindings
 from opencda.core.application.behavior.registry import BehaviorServiceRegistry
@@ -17,12 +16,12 @@ from opencda.core.application.behavior.transport_message import TransportMessage
 from opencda.core.application.behavior.services.aim_server import AIMServerRequest, AIMServerResponse
 from opencda.core.application.behavior.services.movement_controller import MovementControllerRequestMessage
 from opencda.core.application.behavior.services.self_informer import SelfInformerResponse
+from opencda.core.application.behavior.types import Location, Transform
 from .types import AIMClientState
 
 from .utils import draw_trajetory_points, calculate_target_speeds
 
 if TYPE_CHECKING:
-    from opencda.core.application.behavior.types import Location
     from opencda.core.common.vehicle_manager import VehicleManager
 
 
@@ -174,8 +173,8 @@ class AIMClient:
 
     def _build_aim_server_request_messages(self, dst_owner_id: str = BROADCAST_OWNER_ID) -> tuple[TransportMessage[AIMServerRequest], ...]:
         owner = self._get_owner()
-        position = owner.vehicle.get_transform()
-        waypoints = owner.agent.get_local_planner().get_waypoint_buffer()
+        position = Location.from_carla(owner.vehicle.get_transform().location)
+        waypoints = [Transform.from_carla(waypoint[0].transform) for waypoint in owner.agent.get_local_planner().get_waypoint_buffer()]
         payload = AIMServerRequest(
             vehicle_id=owner.id,
             position=position,
@@ -203,7 +202,6 @@ class AIMClient:
             owner.agent._local_planner._vehicle.get_world(),
             control_trajectory,
             size=0.05,
-            color=carla.Color(255, 0, 0),
             life_time=0.1,
         )
 

--- a/opencda/core/application/behavior/services/aim_client/service.py
+++ b/opencda/core/application/behavior/services/aim_client/service.py
@@ -156,18 +156,13 @@ class AIMClient:
             target_speeds = calculate_target_speeds(control_trajectory, 0.05, current_location, current_speed, 111, 2.5, 4.5)
             self.trajectory = deque(zip(control_trajectory, target_speeds))
 
+        if self.trajectory:
             if self.debug:
-                self._draw_control_trajectory(owner, control_trajectory)
-
+                self._draw_control_trajectory(owner, [i[0] for i in self.trajectory])
             target_location, target_speed = self.trajectory.popleft()
             movement_commands.append(self._build_movement_command_message(target_location, target_speed))
-
-        if len(movement_commands) == 0:
-            if self.trajectory:
-                target_location, target_speed = self.trajectory.popleft()
-                movement_commands.append(self._build_movement_command_message(target_location, target_speed))
-            else:
-                self.server_id = BROADCAST_OWNER_ID
+        else:
+            self.server_id = BROADCAST_OWNER_ID
 
         return tuple(movement_commands)
 

--- a/opencda/core/application/behavior/services/aim_client/utils.py
+++ b/opencda/core/application/behavior/services/aim_client/utils.py
@@ -7,7 +7,7 @@ from opencda.core.application.behavior.types import Location
 def calculate_target_speeds(
     trajectory: Sequence[Location],
     dt: float = 0.1,
-    current_location: Location | carla.Location | None = None,
+    current_location: Location | None = None,
     current_speed: float | None = None,
     max_speed: float | None = None,
     max_accel: float | None = None,
@@ -25,7 +25,7 @@ def calculate_target_speeds(
         Time delta between two predicted trajectory points, in seconds.
         The original AIM inference examples use 0.1 s.
 
-    current_location : Location | carla.Location | None
+    current_location : Location | None
         Current ego location. If provided, the speed for the first trajectory
         point is calculated from ego location to trajectory[0].
 
@@ -84,7 +84,7 @@ def calculate_target_speeds(
     return speeds
 
 
-def _distance_2d(first: Location | carla.Location, second: Location | carla.Location) -> float:
+def _distance_2d(first: Location, second: Location) -> float:
     dx = second.x - first.x
     dy = second.y - first.y
     return (dx * dx + dy * dy) ** 0.5

--- a/opencda/core/application/behavior/services/aim_server/aim_model_manager.py
+++ b/opencda/core/application/behavior/services/aim_server/aim_model_manager.py
@@ -134,10 +134,13 @@ class AIMModelManager:
         """
         Run AIM inference for the request batch and return predicted targets.
         """
+        cav_to_delete = []
         for vehicle_id in self.cav_state:
             self.cav_state[vehicle_id]["ttl"] -= 1
             if self.cav_state[vehicle_id]["ttl"] == 0:
-                del self.cav_state[vehicle_id]
+                cav_to_delete.append(vehicle_id)
+        for vehicle_id in cav_to_delete:
+            del self.cav_state[vehicle_id]
 
         for message in messages:
             self._preprocess_cav_data(message)

--- a/opencda/core/application/behavior/services/aim_server/aim_model_manager.py
+++ b/opencda/core/application/behavior/services/aim_server/aim_model_manager.py
@@ -166,7 +166,13 @@ class AIMModelManager:
                 pred_delta = predictions[idx].reshape(30, 2).detach().cpu().numpy()
                 yaw_rad = features[idx][3] - np.deg2rad(90)  # convert to carla yaw
 
-                trajectory = [self.predition_to_location(vehicle_id, pred_delta[i], yaw_rad) for i in range(30)]
+                trajectory = []
+                for local_delta in pred_delta:
+                    location = self.predition_to_location(vehicle_id, local_delta, yaw_rad)
+                    if utils.get_distance(location, self.control_center_carla_location) < self.CONTROL_RADIUS:
+                        trajectory.append(location)
+                    else:
+                        break
                 payload = AIMServerResponse(
                     trajectory=trajectory,
                 )

--- a/opencda/core/application/behavior/services/aim_server/aim_model_manager.py
+++ b/opencda/core/application/behavior/services/aim_server/aim_model_manager.py
@@ -9,7 +9,7 @@ from AIM import AIMModel
 
 from .messages import AIMServerRequest, AIMServerResponse
 from .types import AIMServerState, CavData
-from opencda.core.application.behavior.types import Location
+from opencda.core.application.behavior.types import Location, Transform
 from . import utils
 
 from opencda.core.application.behavior.transport_message import TransportMessage
@@ -72,7 +72,7 @@ class AIMModelManager:
         Normalize and cache incoming CAV data for the current inference step.
         """
         message = transport_message.payload
-        cav_pos = utils.get_sumo_transform(message.position, Location(0, 0, 0)).location
+        cav_pos = utils.get_sumo_location(message.position)
         curr_pos = np.array([cav_pos.x, cav_pos.y])
         distance_to_center = self._get_distance_to_center(curr_pos)
         vehicle_id = message.vehicle_id
@@ -80,7 +80,7 @@ class AIMModelManager:
         if distance_to_center != -1 and distance_to_center < self.CONTROL_RADIUS:
             self.cav_data[vehicle_id] = CavData(
                 intention=self.get_intention(vehicle_id, message.waypoints, self.control_center_carla_location),
-                pos=message.position.location,
+                pos=message.position,
                 sumo_pos=curr_pos,
                 speed=message.speed,
                 yaw=message.yaw,
@@ -226,13 +226,13 @@ class AIMModelManager:
             if vehicle_id not in self.cav_data:
                 del self.trajs[vehicle_id]
 
-    def get_intention(self, vehicle_id: str, waypoints: Sequence[Any], mid: Location) -> str:
+    def get_intention(self, vehicle_id: str, waypoints: Sequence[Transform], mid: Location) -> str:
         if vehicle_id not in self.trajs or self.trajs[vehicle_id] == [] or self.trajs[vehicle_id][-1][-1] == "null":
             return self.get_opencda_intention(waypoints, mid)
         else:
             return self.trajs[vehicle_id][-1][-1]
 
-    def get_opencda_intention(self, waypoints: Sequence[Any], mid: Location) -> str:
+    def get_opencda_intention(self, waypoints: Sequence[Transform], mid: Location) -> str:
         """
         Gets intention by averaged rotation to pass 3 next waypoints.
 
@@ -248,10 +248,10 @@ class AIMModelManager:
 
         waypoint_index = 0
 
-        if utils.get_distance(mid, waypoints[0][0].transform.location) > self.CONTROL_RADIUS:
+        if utils.get_distance(mid, waypoints[0].location) > self.CONTROL_RADIUS:
             logger.debug("Car not in radius")
             return "null"
-        while utils.get_distance(mid, waypoints[waypoint_index][0].transform.location) > self.CONTROL_RADIUS:
+        while utils.get_distance(mid, waypoints[waypoint_index].location) > self.CONTROL_RADIUS:
             waypoint_index += 1
             if waypoint_index >= len(waypoints):
                 logger.debug("No waypoints in radius")
@@ -259,19 +259,19 @@ class AIMModelManager:
 
         first_waypoint = waypoints[waypoint_index]
         first_waypoint_index = waypoint_index
-        while utils.get_distance(mid, waypoints[waypoint_index][0].transform.location) <= self.CONTROL_RADIUS and waypoint_index < len(waypoints) - 1:
+        while utils.get_distance(mid, waypoints[waypoint_index].location) <= self.CONTROL_RADIUS and waypoint_index < len(waypoints) - 1:
             waypoint_index += 1
 
         # average the values of several points to reduce noise
-        mean_yaw = 0
+        mean_yaw = 0.0
         waypoints_in_radius = waypoint_index - first_waypoint_index
         if waypoints_in_radius < 3 and waypoint_index > 3:
             logger.warning("Too few waypoints in radius")
         else:
             for i in range(3):
-                mean_yaw += waypoints[waypoint_index - i][0].transform.rotation.yaw
+                mean_yaw += waypoints[waypoint_index - i].rotation.yaw
         mean_yaw //= 3
-        rotation = (mean_yaw - first_waypoint[0].transform.rotation.yaw + 360) % 360
+        rotation = (mean_yaw - first_waypoint.rotation.yaw + 360) % 360
         return utils.get_intention_by_rotation(rotation)
 
     def encoding_scenario_features(self) -> tuple[np.ndarray, list[str]]:

--- a/opencda/core/application/behavior/services/aim_server/messages.py
+++ b/opencda/core/application/behavior/services/aim_server/messages.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Sequence
+from typing import TYPE_CHECKING, Sequence
 
 if TYPE_CHECKING:
     from opencda.core.application.behavior.types import Location, Transform
@@ -14,10 +14,10 @@ class AIMServerRequest:
     """CAV state and route context routed to the AIM server service."""
 
     vehicle_id: str
-    position: Transform
+    position: Location
     speed: float
     yaw: float
-    waypoints: Sequence[Any]
+    waypoints: Sequence[Transform]
 
 
 @dataclass(frozen=True)

--- a/opencda/core/application/behavior/services/aim_server/utils.py
+++ b/opencda/core/application/behavior/services/aim_server/utils.py
@@ -35,7 +35,7 @@ def get_intention_vector(intention: str = "straight") -> np.ndarray:
     return intention_feature
 
 
-def get_intention_by_rotation(rotation: int) -> str:
+def get_intention_by_rotation(rotation: float) -> str:
     """
     Distinguishes vehicle intention by its rotation
 

--- a/opencda/core/attack/adversary_framework/attacks/aim_client_request_position_spoofing/config.yaml
+++ b/opencda/core/attack/adversary_framework/attacks/aim_client_request_position_spoofing/config.yaml
@@ -51,7 +51,7 @@ attack:
         - request.submit
       params:
         rewrites:
-          - path: payload.position.location.x
+          - path: payload.position.x
             operation: add
             value: -20.0
       stage_stop_trigger:

--- a/opencda/core/attack/adversary_framework/attacks/aim_client_reservation_stealing/config.yaml
+++ b/opencda/core/attack/adversary_framework/attacks/aim_client_reservation_stealing/config.yaml
@@ -51,7 +51,7 @@ attack:
         - request.submit
       params:
         rewrites:
-          - path: payload.position.location.x
+          - path: payload.position.x
             operation: add
             value: -25.0
           - path: payload.speed


### PR DESCRIPTION
## Summary

Removes direct CARLA object usage from AIM service messages and improves the trajectory returned by the AIM server. This makes AIM client/server communication cleaner and keeps returned control trajectories limited to the active AIM control area.

## Related issue

## Changes

- Replaced raw CARLA transform/waypoint objects in AIM service requests with plain `Location` and typed `Transform` data.
- Updated AIM client and server logic to work with the decoupled request schema.
- Improved AIM server trajectory output by returning only predicted points inside the control radius.
- Updated AIM attack configs to match the new AIM request payload structure.

## Validation

<!-- How was this tested or validated? -->

- [x] Simulation run
- [x] Manual verification
- [ ] Not applicable

## Checklist

- [x] Linked the related issue
- [x] Kept the PR focused and reviewable
- [ ] Updated documentation if needed
- [x] Added or updated validation steps if needed
