### PR TITLE
[attack] Attack stage debug logging, little fixes and enhancements

### DIFF
--- a/opencda/core/application/behavior/capability.py
+++ b/opencda/core/application/behavior/capability.py
@@ -8,7 +8,7 @@ from typing import Any, TypeAlias
 
 
 class Capability(str, Enum):
-    """Сross-service capability vocabulary."""
+    """Cross-service capability vocabulary."""
 
     REQUEST_OBSERVE = "request.observe"
     REQUEST_SUBMIT = "request.submit"

--- a/opencda/core/application/behavior/services/aim_client/utils.py
+++ b/opencda/core/application/behavior/services/aim_client/utils.py
@@ -116,5 +116,5 @@ def draw_trajetory_points(
     size: float = 0.1,
 ) -> None:
     for location in locations:
-        loc = carla.Location(location.x, location.y, location.z)
+        loc = carla.Location(location.x, location.y, location.z + 1)
         world.debug.draw_point(loc, size=size, color=color, life_time=life_time)

--- a/opencda/core/attack/adversary_framework/attacks/aim_server_request_ddos/config.yaml
+++ b/opencda/core/attack/adversary_framework/attacks/aim_server_request_ddos/config.yaml
@@ -20,8 +20,8 @@ attack:
       node_type: rsu
       service_type: aim_server
       field: tracked_vehicle_count
-    verb: increased
-    value: 1
+    verb: gte
+    value: 0
 
   stop_trigger:
     source:
@@ -29,7 +29,7 @@ attack:
       node_type: rsu
       service_type: aim_server
       field: tracked_vehicle_count
-    verb: eq
+    verb: lt
     value: 0
 
   targets:
@@ -50,19 +50,11 @@ attack:
         - request.observe
       params:
         drop_rate: 0.3
-      stage_start_trigger:
-        source:
-          kind: snapshot
-          node_type: rsu
-          service_type: aim_server
-          field: tracked_vehicle_count
-        verb: increased
-        value: 1
       stage_stop_trigger:
         source:
           kind: snapshot
           node_type: rsu
           service_type: aim_server
           field: tracked_vehicle_count
-        verb: eq
+        verb: lt
         value: 0

--- a/opencda/core/attack/adversary_framework/stages/dropper/stage.py
+++ b/opencda/core/attack/adversary_framework/stages/dropper/stage.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 from collections.abc import Iterable, Mapping, Sequence
+from functools import partial
+import logging
 import random
 from typing import Any
 
@@ -10,7 +12,9 @@ from opencda.core.application.behavior.behavior_service_protocol import Behavior
 from opencda.core.application.behavior.capability import Capability
 from opencda.core.attack.adversary_framework.models import AttackStageResult, Status
 from opencda.core.attack.adversary_framework.stage_registry import AttackStageRegistry
-from opencda.core.attack.adversary_framework.utils import RestoreCallback, install_output_interceptor
+from opencda.core.attack.adversary_framework.utils import RestoreCallback, install_output_interceptor, log_stage_object_transition
+
+logger = logging.getLogger("cavise.opencda.opencda.core.attack.adversary_framework.stages.dropper")
 
 
 @AttackStageRegistry.register
@@ -52,7 +56,7 @@ class DropperStage:
                 restore_callback = install_output_interceptor(
                     service,
                     capability,
-                    rewrite_result=self._drop_output,
+                    rewrite_result=partial(self._drop_output, service, capability),
                 )
                 self._restore_callbacks.append(restore_callback)
 
@@ -71,7 +75,25 @@ class DropperStage:
             restore_callback = self._restore_callbacks.pop()
             restore_callback()
 
-    def _drop_output(self, output: Any) -> Any:
+    def _drop_output(
+        self,
+        service: BehaviorService[Any, Any],
+        capability: Capability,
+        output: Any,
+    ) -> Any:
+        dropped_output = self._drop_output_value(output)
+        log_stage_object_transition(
+            logger,
+            stage_name=self.stage_name,
+            action="dropped",
+            service=service,
+            capability=capability,
+            before=output,
+            after=dropped_output,
+        )
+        return dropped_output
+
+    def _drop_output_value(self, output: Any) -> Any:
         is_batch_output = self._is_batch_output(output)
         if self._drop_rate <= 0.0:
             if is_batch_output:

--- a/opencda/core/attack/adversary_framework/stages/replayer/stage.py
+++ b/opencda/core/attack/adversary_framework/stages/replayer/stage.py
@@ -4,13 +4,16 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 from functools import partial
+import logging
 from typing import Any
 
 from opencda.core.application.behavior.behavior_service_protocol import BehaviorService
 from opencda.core.application.behavior.capability import Capability
 from opencda.core.attack.adversary_framework.models import AttackStageResult, Status
 from opencda.core.attack.adversary_framework.stage_registry import AttackStageRegistry
-from opencda.core.attack.adversary_framework.utils import RestoreCallback, install_output_interceptor, safe_clone
+from opencda.core.attack.adversary_framework.utils import RestoreCallback, install_output_interceptor, log_stage_object_transition, safe_clone
+
+logger = logging.getLogger("cavise.opencda.opencda.core.attack.adversary_framework.stages.replayer")
 
 
 @AttackStageRegistry.register
@@ -77,6 +80,17 @@ class ReplayerStage:
         self._previous_outputs_by_binding[binding_key] = safe_clone(output)
 
         if previous_output is None:
-            return output
+            replayed_output = output
+        else:
+            replayed_output = safe_clone(previous_output)
 
-        return safe_clone(previous_output)
+        log_stage_object_transition(
+            logger,
+            stage_name=self.stage_name,
+            action="replayed",
+            service=service,
+            capability=capability,
+            before=output,
+            after=replayed_output,
+        )
+        return replayed_output

--- a/opencda/core/attack/adversary_framework/stages/sniffer/stage.py
+++ b/opencda/core/attack/adversary_framework/stages/sniffer/stage.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 from functools import partial
+import logging
 from typing import Any
 
 from opencda.core.application.behavior.behavior_service_protocol import BehaviorService
@@ -11,7 +12,9 @@ from opencda.core.application.behavior.capability import Capability
 from opencda.core.attack.adversary_framework.models import AttackStageResult, Status
 from opencda.core.attack.adversary_framework.stage_registry import AttackStageRegistry
 from opencda.core.attack.adversary_framework.stages.sniffer.types import ObservedOutput
-from opencda.core.attack.adversary_framework.utils import RestoreCallback, install_output_interceptor, safe_clone
+from opencda.core.attack.adversary_framework.utils import RestoreCallback, install_output_interceptor, log_stage_object_transition, safe_clone
+
+logger = logging.getLogger("cavise.opencda.opencda.core.attack.adversary_framework.stages.sniffer")
 
 
 @AttackStageRegistry.register
@@ -78,5 +81,14 @@ class SnifferStage:
                 capability=capability,
                 output=safe_clone(output),
             )
+        )
+        log_stage_object_transition(
+            logger,
+            stage_name=self.stage_name,
+            action="observed",
+            service=service,
+            capability=capability,
+            before=output,
+            after=output,
         )
         return output

--- a/opencda/core/attack/adversary_framework/stages/spoofer/stage.py
+++ b/opencda/core/attack/adversary_framework/stages/spoofer/stage.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from collections.abc import Mapping, MutableMapping, MutableSequence, Sequence
 from dataclasses import dataclass, is_dataclass
+from functools import partial
+import logging
 from typing import Any
 
 from opencda.core.application.behavior.behavior_service_protocol import BehaviorService
@@ -11,7 +13,9 @@ from opencda.core.application.behavior.capability import Capability
 from opencda.core.application.behavior.transport_message import TransportMessage
 from opencda.core.attack.adversary_framework.models import AttackStageResult, Status
 from opencda.core.attack.adversary_framework.stage_registry import AttackStageRegistry
-from opencda.core.attack.adversary_framework.utils import RestoreCallback, install_output_interceptor, safe_clone
+from opencda.core.attack.adversary_framework.utils import RestoreCallback, install_output_interceptor, log_stage_object_transition, safe_clone
+
+logger = logging.getLogger("cavise.opencda.opencda.core.attack.adversary_framework.stages.spoofer")
 
 
 @dataclass(frozen=True, slots=True)
@@ -57,7 +61,7 @@ class SpooferStage:
                 restore_callback = install_output_interceptor(
                     service,
                     capability,
-                    rewrite_result=self._spoof_output,
+                    rewrite_result=partial(self._spoof_output, service, capability),
                 )
                 self._restore_callbacks.append(restore_callback)
 
@@ -73,13 +77,31 @@ class SpooferStage:
             restore_callback = self._restore_callbacks.pop()
             restore_callback()
 
-    def _spoof_output(self, output: Any) -> Any:
+    def _spoof_output(
+        self,
+        service: BehaviorService[Any, Any],
+        capability: Capability,
+        output: Any,
+    ) -> Any:
+        spoofed_output = self._spoof_output_value(output)
+        log_stage_object_transition(
+            logger,
+            stage_name=self.stage_name,
+            action="spoofed",
+            service=service,
+            capability=capability,
+            before=output,
+            after=spoofed_output,
+        )
+        return spoofed_output
+
+    def _spoof_output_value(self, output: Any) -> Any:
         if isinstance(output, TransportMessage):
             return self._spoof_message(output)
         if isinstance(output, tuple):
-            return tuple(self._spoof_output(item) for item in output)
+            return tuple(self._spoof_output_value(item) for item in output)
         if isinstance(output, list):
-            return [self._spoof_output(item) for item in output]
+            return [self._spoof_output_value(item) for item in output]
         return output
 
     def _spoof_message(self, message: TransportMessage[Any]) -> TransportMessage[Any]:

--- a/opencda/core/attack/adversary_framework/utils.py
+++ b/opencda/core/attack/adversary_framework/utils.py
@@ -24,6 +24,33 @@ _MISSING = object()
 logger = logging.getLogger("cavise.opencda.opencda.core.attack.adversary_framework.utils")
 
 
+def log_stage_object_transition(
+    stage_logger: logging.Logger,
+    *,
+    stage_name: str,
+    action: str,
+    before: Any,
+    after: Any,
+    service: BehaviorService[Any, Any] | None = None,
+    capability: Capability | None = None,
+) -> None:
+    """Log a stage-controlled object transition when DEBUG logging is enabled."""
+    if not stage_logger.isEnabledFor(logging.DEBUG):
+        return
+
+    service_type = getattr(service, "service_type", None)
+    capability_label = capability.value if capability is not None else None
+    stage_logger.debug(
+        "Attack stage '%s' %s object state: service=%r capability=%r\nbefore=%r\nafter=%r.",
+        stage_name,
+        action,
+        service_type,
+        capability_label,
+        before,
+        after,
+    )
+
+
 # TODO: Consider using a more robust cloning strategy if needed, such as copyreg or custom __deepcopy__ implementations on CARLA types.
 def safe_clone(value: Any) -> Any:
     """Clone common Python structures while tolerating opaque runtime objects such as CARLA types."""


### PR DESCRIPTION
## Summary

Adds DEBUG-level logging for adversary framework attack stages, making it possible to inspect how each stage changes service capability outputs during attack execution. Also updates the AIM server request DDoS config and includes small cleanup/debug-visualization fixes.

## Related issue

Closes #

## Changes

- Added a shared `log_stage_object_transition` helper for DEBUG logs with stage name, action, service type, capability, and before/after object state.
- Wired transition logging into `dropper`, `replayer`, `sniffer`, and `spoofer` stages.
- Passed service/capability context into stage rewrite callbacks so logs identify the affected capability handler.
- Updated `aim_server_request_ddos` config to start once requirements are met and avoid stopping when tracked vehicle count returns to zero.
- Fixed the `Capability` doc-string typo and raised AIM client trajectory debug points above the ground for clearer visualization.


## Validation

<!-- How was this tested or validated? -->

- [x] Simulation run
- [x] Manual verification
- [ ] Not applicable

## Checklist

- [x] Linked the related issue
- [x] Kept the PR focused and reviewable
- [ ] Updated documentation if needed
- [ ] Added or updated validation steps if needed
