### PR TITLE
[ci] Added workflow from lib

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,88 +1,36 @@
 name: Lint, Format, Type and Unused code Check
 
-on: [ pull_request ]
+on:
+  pull_request:
 
 jobs:
-  lint:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-      - name: Run ruff check
-        uses: astral-sh/ruff-action@v3
-        with:
-          args: "check"
-
-  format-check:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-      - name: Run ruff format check with diff
-        uses: astral-sh/ruff-action@v3
-        with:
-          args: "format --check --diff"
+  ruff:
+    uses: CAVISE/pipelines/.github/workflows/python-ruff.yml@ci/opencda-workflow
+    with:
+      run-lint: true
+      run-format-check: true
 
   type-check:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: "3.12"
-      - name: Install Dependencies
-        run: pip install mypy mypy-protobuf grpcio-tools
-      - name: Generate protobufs modules
-        run: |
-          python -m grpc_tools.protoc \
-            -I opencda/core/common/communication/messages \
-            --python_out=opencda/core/common/communication/protos/cavise \
-            --mypy_out=opencda/core/common/communication/protos/cavise \
-            opencda/core/common/communication/messages/capi.proto \
-            opencda/core/common/communication/messages/artery.proto \
-            opencda/core/common/communication/messages/opencda.proto \
-            opencda/core/common/communication/messages/entity.proto
-      - name: Run mypy
-        run: mypy . --follow-imports=silent
+    uses: CAVISE/pipelines/.github/workflows/python-mypy.yml@ci/opencda-workflow
+    with:
+      python-version: "3.12"
+      target-path: .
+      follow-imports-silent: true
+      protobuf-generate: true
+      protobuf-source-dir: opencda/core/common/communication/messages
+      protobuf-output-dir: opencda/core/common/communication/protos/cavise
+      protobuf-messages: '["capi", "artery", "opencda", "entity"]'
+      protobuf-mypy-out: true
 
   unused-code-check:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: "3.12"
-      - name: Install Dependencies
-        run: pip install deadcode
-      - name: Run deadcode
-        run: |
-          python - <<'PY'
-          import sys
-          from deadcode.cli import main
-
-          result = main(['.'])
-          if result is not None:
-              print(result)
-              sys.exit(1)
-          PY
+    uses: CAVISE/pipelines/.github/workflows/python-deadcode.yml@ci/opencda-workflow
+    with:
+      python-version: "3.12"
+      target-path: .
 
   pre-commit:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: '3.12'
-      - name: Run pre-commit
-        uses: pre-commit/action@v3.0.1
-        env:
-          SKIP: ruff-check,ruff-format,pretty-format-json
-        with:
-          extra_args: >-
-            --all-files
+    uses: CAVISE/pipelines/.github/workflows/python-pre-commit.yml@ci/opencda-workflow
+    with:
+      python-version: "3.12"
+      skip-hooks: ruff-check,ruff-format,pretty-format-json
+      all-files: true

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,4 +1,4 @@
-name: Lint, Format, Type and Unused code Check
+name: Lint, Format, Type and Unused code checks
 
 on:
   pull_request:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -5,13 +5,13 @@ on:
 
 jobs:
   ruff:
-    uses: CAVISE/pipelines/.github/workflows/python-ruff.yml@ci/opencda-workflow
+    uses: CAVISE/pipelines/.github/workflows/python-ruff.yml@main
     with:
       run-lint: true
       run-format-check: true
 
   type-check:
-    uses: CAVISE/pipelines/.github/workflows/python-mypy.yml@ci/opencda-workflow
+    uses: CAVISE/pipelines/.github/workflows/python-mypy.yml@main
     with:
       python-version: "3.12"
       target-path: .
@@ -23,13 +23,13 @@ jobs:
       protobuf-mypy-out: true
 
   unused-code-check:
-    uses: CAVISE/pipelines/.github/workflows/python-deadcode.yml@ci/opencda-workflow
+    uses: CAVISE/pipelines/.github/workflows/python-deadcode.yml@main
     with:
       python-version: "3.12"
       target-path: .
 
   pre-commit:
-    uses: CAVISE/pipelines/.github/workflows/python-pre-commit.yml@ci/opencda-workflow
+    uses: CAVISE/pipelines/.github/workflows/python-pre-commit.yml@main
     with:
       python-version: "3.12"
       skip-hooks: ruff-check,ruff-format,pretty-format-json

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,4 @@
-name: Tests
+name: Opencda Tests
 
 on:
   workflow_dispatch:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,62 +1,27 @@
-name: Tests (matrix, CI deps)
+name: Tests
 
 on:
   workflow_dispatch:
   pull_request:
+
 jobs:
   pytest:
-    runs-on: ubuntu-latest
-
-    strategy:
+    uses: CAVISE/pipelines/.github/workflows/python-pytest.yml@ci/opencda-workflow
+    with:
+      python-versions: '["3.12"]'
       fail-fast: false
-      matrix:
-        python-version: ["3.12"]
-
-    env:
-      MPLBACKEND: Agg
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Setup Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: ${{ matrix.python-version }}
-          cache: pip
-          cache-dependency-path: |
-            .github/workflows/requirements/requirements-ci.txt
-            pyproject.toml
-      # CI minimal
-      - name: Install dependencies
-        shell: bash
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r .github/workflows/requirements/requirements-ci.txt
-
-      - name: Generate protobufs (capi)
-        shell: bash
-        run: |
-          # Ensure output dir exists for protoc python_out
-          mkdir -p opencda/core/common/communication/protos/cavise
-
-          # Sanity: protoc must exist
-          command -v protoc
-          protoc --version
-
-          # Generate capi_pb2.py (required by MessageHandler/serialize imports)
-          python -c "from opencda.core.common.communication.toolchain import CommunicationToolchain; CommunicationToolchain.handle_messages(['capi'])"
-      # do not stop after first failure
-      - name: Run tests
-        run: |
-          mkdir -p reports
-          pytest -ra --maxfail=0 --continue-on-collection-errors \
-            --junitxml=reports/pytest-${{ matrix.python-version }}.xml
-      # even if tests failed
-      - name: Upload JUnit report
-        # actions/upload-artifact typically fails under nektos/act (no ACTIONS_RUNTIME_TOKEN)
-        if: always() && !env.ACT
-        uses: actions/upload-artifact@v7
-        with:
-          name: pytest-junit-${{ matrix.python-version }}
-          path: reports/pytest-${{ matrix.python-version }}.xml
+      cache-dependency-path: |
+        .github/workflows/requirements/requirements-ci.txt
+        pyproject.toml
+      requirements-file: .github/workflows/requirements/requirements-ci.txt
+      matplotlib-backend: Agg
+      protobuf-generate: true
+      protobuf-source-dir: opencda/core/common/communication/messages
+      protobuf-output-dir: opencda/core/common/communication/protos/cavise
+      protobuf-messages: '["capi"]'
+      protobuf-mypy-out: true
+      pytest-maxfail: 0
+      pytest-continue-on-collection-errors: true
+      report-dir: reports
+      upload-artifact: true
+      artifact-name-prefix: pytest-junit

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   pytest:
-    uses: CAVISE/pipelines/.github/workflows/python-pytest.yml@ci/opencda-workflow
+    uses: CAVISE/pipelines/.github/workflows/python-pytest.yml@main
     with:
       python-versions: '["3.12"]'
       fail-fast: false

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ jobs:
       protobuf-generate: true
       protobuf-source-dir: opencda/core/common/communication/messages
       protobuf-output-dir: opencda/core/common/communication/protos/cavise
-      protobuf-messages: '["capi"]'
+      protobuf-messages: '["entity", "opencda", "artery", "capi"]'
       protobuf-mypy-out: true
       pytest-maxfail: 0
       pytest-continue-on-collection-errors: true


### PR DESCRIPTION
## Summary

Migrates OpenCDA CI to reusable workflows from the centralized `CAVISE/pipelines` repository. This keeps OpenCDA workflow files focused on triggers and repository-specific configuration while moving shared Python CI logic into reusable pipeline workflows.

## Related issue

Closes #

## Changes

- Replaced inline OpenCDA test workflow steps with `python-pytest.yml` from `CAVISE/pipelines`.
- Replaced inline PR checks with reusable ruff, mypy, deadcode, and pre-commit workflows.
- Preserved OpenCDA-specific settings for requirements, protobuf generation, pytest options, and pre-commit skips.

## Validation

- [ ] Simulation run
- [x] Manual verification
- [ ] Not applicable

Validated workflow YAML parsing and checked diffs with `git diff --check`.

## Checklist

- [ ] Linked the related issue
- [x] Kept the PR focused and reviewable
- [ ] Updated documentation if needed
- [ ] Added or updated validation steps if needed
