### PR TITLE
[attack] Add ability to change arrays in spoofing attack

### DIFF
--- a/opencda/core/attack/adversary_framework/attacks/aim_server_trajectory_spoofing/config.yaml
+++ b/opencda/core/attack/adversary_framework/attacks/aim_server_trajectory_spoofing/config.yaml
@@ -1,0 +1,69 @@
+attack:
+  name: aim_server_trajectory_spoofing
+
+  requirements:
+    all:
+      - source:
+          kind: snapshot
+          node_type: rsu
+          service_type: aim_server
+        verb: exists
+      - source:
+          kind: snapshot
+          node_type: vehicle
+          service_type: aim_client
+        verb: exists
+
+  start_trigger:
+    source:
+      kind: snapshot
+      node_type: rsu
+      service_type: aim_server
+      field: tracked_vehicle_count
+    verb: gte
+    value: 0
+
+  stop_trigger:
+    source:
+      kind: snapshot
+      node_type: rsu
+      service_type: aim_server
+      field: tracked_vehicle_count
+    verb: eq
+    value: 10
+
+  targets:
+    kind: service_state_field
+    source:
+      kind: snapshot
+      node_type: rsu
+      service_type: aim_server
+      field: owner_id
+    resolve_to:
+      node_type: rsu
+      service_type: aim_server
+
+  stages:
+    - id: spoof_aim_server_trajectory
+      type: spoofer
+      capabilities:
+        - response.submit
+      params:
+        rewrites:
+          - path: payload.trajectory[0].x
+            operation: add
+            value: 50.0
+          - path: payload.trajectory[1].x
+            operation: add
+            value: 50.0
+          - path: payload.trajectory[2].x
+            operation: add
+            value: 50.0
+      stage_stop_trigger:
+        source:
+          kind: snapshot
+          node_type: rsu
+          service_type: aim_server
+          field: tracked_vehicle_count
+        verb: eq
+        value: 10

--- a/opencda/core/attack/adversary_framework/stages/spoofer/stage.py
+++ b/opencda/core/attack/adversary_framework/stages/spoofer/stage.py
@@ -6,6 +6,7 @@ from collections.abc import Mapping, MutableMapping, MutableSequence, Sequence
 from dataclasses import dataclass, is_dataclass
 from functools import partial
 import logging
+import re
 from typing import Any
 
 from opencda.core.application.behavior.behavior_service_protocol import BehaviorService
@@ -16,6 +17,8 @@ from opencda.core.attack.adversary_framework.stage_registry import AttackStageRe
 from opencda.core.attack.adversary_framework.utils import RestoreCallback, install_output_interceptor, log_stage_object_transition, safe_clone
 
 logger = logging.getLogger("cavise.opencda.opencda.core.attack.adversary_framework.stages.spoofer")
+
+_BRACKET_INDEX_PATTERN = re.compile(r"\[(\d+)\]")
 
 
 @dataclass(frozen=True, slots=True)
@@ -142,9 +145,10 @@ class SpooferStage:
             if not isinstance(raw_path, str) or not raw_path:
                 raise ValueError(f"SpooferStage rewrite #{index} must define a non-empty string 'path'.")
 
-            path = tuple(raw_path.split("."))
-            if any(not segment for segment in path):
-                raise ValueError(f"SpooferStage rewrite #{index} has invalid path '{raw_path}'.")
+            try:
+                path = cls._tokenize_path(raw_path)
+            except ValueError as exc:
+                raise ValueError(f"SpooferStage rewrite #{index} has invalid path '{raw_path}': {exc}") from exc
 
             operation = str(raw_rewrite.get("operation", "set"))
             if operation not in cls._supported_operations:
@@ -163,6 +167,19 @@ class SpooferStage:
             )
 
         return tuple(rewrite_rules)
+
+    @staticmethod
+    def _tokenize_path(raw_path: str) -> tuple[str, ...]:
+        """Split a dotted path with optional ``[N]`` index segments into atomic segments."""
+        converted = _BRACKET_INDEX_PATTERN.sub(r".\1", raw_path)
+        if "[" in converted or "]" in converted:
+            raise ValueError("brackets must enclose a non-negative integer index")
+        segments = converted.split(".")
+        if segments and segments[0] == "":
+            segments = segments[1:]
+        if not segments or any(not segment for segment in segments):
+            raise ValueError("empty path segment")
+        return tuple(segments)
 
     @staticmethod
     def _path_exists(root: Any, path: tuple[str, ...]) -> bool:


### PR DESCRIPTION
## Summary

<!-- What does this PR change? Why is it needed? -->
Fix SpooferStage silently dropping rewrite rules whose path uses the [N] bracket index syntax (e.g. payload.trajectory[0].x). Previously the path parser split only on ., so a segment like trajectory[0] was treated as an attribute name, raised AttributeError, and the rule was swallowed by _path_exists without any log. The aim_server_trajectory_spoofing attack was a no-op because of this.

## Related issue

<!-- Use Closes #123 only if this PR fully resolves the issue. -->

## Changes

- SpooferStage._tokenize_path now accepts both a.b.0 and a.b[0] forms; payload.trajectory[0].x resolves the same as payload.trajectory.0.x.
- aim_server_trajectory_spoofing stage added

## Validation

<!-- How was this tested or validated? -->

- [x] Simulation run
- [x] Manual verification
- [ ] Not applicable

## Checklist

- [x] Linked the related issue
- [x] Kept the PR focused and reviewable
- [ ] Updated documentation if needed
- [ ] Added or updated validation steps if needed
