### PR TITLE
[services] Move default movement control to service

### DIFF
--- a/opencda/core/application/behavior/services/default_movement_request/__init__.py
+++ b/opencda/core/application/behavior/services/default_movement_request/__init__.py
@@ -1,0 +1,9 @@
+"""Default movement-request behavior service package."""
+
+from .service import DefaultMovementRequest
+from .types import DefaultMovementRequestState
+
+__all__ = [
+    "DefaultMovementRequest",
+    "DefaultMovementRequestState",
+]

--- a/opencda/core/application/behavior/services/default_movement_request/service.py
+++ b/opencda/core/application/behavior/services/default_movement_request/service.py
@@ -1,0 +1,77 @@
+"""Default movement-request behavior service implementation."""
+
+from __future__ import annotations
+
+import logging
+import weakref
+from collections.abc import Sequence
+from typing import TYPE_CHECKING, Any
+
+from opencda.core.application.behavior.capability import CapabilityBindings
+from opencda.core.application.behavior.registry import BehaviorServiceRegistry
+from opencda.core.application.behavior.transport_message import TransportMessage
+from opencda.core.application.behavior.services.movement_controller import MovementControllerRequestMessage
+from .types import DefaultMovementRequestState
+
+if TYPE_CHECKING:
+    from opencda.core.common.vehicle_manager import VehicleManager
+
+
+logger = logging.getLogger("cavise.opencda.opencda.core.application.behavior.services.default_movement_request")
+
+
+@BehaviorServiceRegistry.register
+class DefaultMovementRequest:
+    """Behavior service that emits a no-op movement request as a fallback control input."""
+
+    service_type: str = "default_movement_request"
+    priority: int = 3
+
+    @property
+    def capability_bindings(self) -> CapabilityBindings:
+        return {}
+
+    def __init__(self, priority: int = 3) -> None:
+        self.priority = priority
+        self._owner_ref: weakref.ReferenceType[VehicleManager] | None = None
+
+    def _get_owner(self) -> VehicleManager:
+        owner_ref = self._owner_ref
+        if owner_ref is None:
+            raise RuntimeError("DefaultMovementRequest is not attached to an owner.")
+
+        owner = owner_ref()
+        if owner is None:
+            raise RuntimeError("DefaultMovementRequest owner is no longer available.")
+
+        return owner
+
+    def on_attach(self, owner: VehicleManager) -> None:
+        self._owner_ref = weakref.ref(owner)
+
+    def on_detach(self) -> None:
+        self._owner_ref = None
+
+    def get_state(self) -> DefaultMovementRequestState:
+        owner = self._get_owner()
+        return DefaultMovementRequestState(
+            service_type=self.service_type,
+            owner_id=owner.id,
+        )
+
+    def _build_default_movement_request(self) -> TransportMessage[MovementControllerRequestMessage]:
+        owner = self._get_owner()
+        payload = MovementControllerRequestMessage(target_speed=None, target_location=None)
+        return TransportMessage(
+            src_owner_id=owner.id,
+            src_service_type=self.service_type,
+            dst_owner_id=owner.id,
+            dst_service_type="movement_controller",
+            payload=payload,
+        )
+
+    def process(
+        self,
+        messages: Sequence[TransportMessage[Any]],
+    ) -> tuple[TransportMessage[MovementControllerRequestMessage], ...]:
+        return (self._build_default_movement_request(),)

--- a/opencda/core/application/behavior/services/default_movement_request/types.py
+++ b/opencda/core/application/behavior/services/default_movement_request/types.py
@@ -1,0 +1,7 @@
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class DefaultMovementRequestState:
+    service_type: str
+    owner_id: str | None

--- a/opencda/core/application/behavior/services/default_movement_request/types.py
+++ b/opencda/core/application/behavior/services/default_movement_request/types.py
@@ -4,4 +4,4 @@ from dataclasses import dataclass
 @dataclass(frozen=True, slots=True)
 class DefaultMovementRequestState:
     service_type: str
-    owner_id: str | None
+    owner_id: str

--- a/opencda/core/common/vehicle_manager.py
+++ b/opencda/core/common/vehicle_manager.py
@@ -19,7 +19,6 @@ from opencda.core.plan.behavior_agent import BehaviorAgent
 from opencda.core.map.map_manager import MapManager
 from opencda.core.common.data_dumper import DataDumper
 from opencda.core.application.behavior.types import Location
-from opencda.core.application.behavior.services.movement_controller.messages import MovementControllerRequestMessage
 
 logger = logging.getLogger("cavise.opencda.opencda.core.common.vehicle_manager")
 
@@ -403,22 +402,11 @@ class VehicleManager(object):
 
     def run_step(
         self,
-        target_speed: float | None = None,
         messages: list[TransportMessage[Any]] = [],
     ) -> tuple[list[TransportMessage[Any]], dict[str, Any]]:
         """
         Execute one step of navigation.
         """
-        payload = MovementControllerRequestMessage(target_speed=target_speed, target_location=None)
-        messages.append(
-            TransportMessage(
-                src_owner_id=self.id,
-                src_service_type="",
-                dst_owner_id=self.id,
-                dst_service_type="movement_controller",
-                payload=payload,
-            )
-        )
         self.update_behavior_services(messages)
 
         return (self.behavior_service_results, self.behavior_service_states)

--- a/opencda/scenario_testing/config_yaml/aim_check.yaml
+++ b/opencda/scenario_testing/config_yaml/aim_check.yaml
@@ -3,6 +3,8 @@ description: |-
 
 world:
   town: Town04
+  weather:
+    sun_altitude_angle: -90
 
 blueprint:
   use_multi_class_bp: true
@@ -115,6 +117,7 @@ scenario:
       color: [156, 255, 206]
       behavior_services:
         - type: self_informer
+        - type: default_movement_request
         - type: aim_client
           debug: true
         - type: movement_controller
@@ -126,6 +129,7 @@ scenario:
       color: [156, 255, 206]
       behavior_services:
         - type: self_informer
+        - type: default_movement_request
         - type: aim_client
           debug: true
         - type: movement_controller
@@ -137,6 +141,7 @@ scenario:
       color: [156, 255, 206]
       behavior_services:
         - type: self_informer
+        - type: default_movement_request
         - type: aim_client
           debug: true
         - type: movement_controller
@@ -148,6 +153,7 @@ scenario:
       color: [156, 255, 206]
       behavior_services:
         - type: self_informer
+        - type: default_movement_request
         - type: aim_client
           debug: true
         - type: movement_controller

--- a/opencda/scenario_testing/config_yaml/codriving_check.yaml
+++ b/opencda/scenario_testing/config_yaml/codriving_check.yaml
@@ -111,5 +111,6 @@ scenario:
         communication_range: 45
       behavior_services:
         - type: self_informer
+        - type: default_movement_request
         - type: aim_client
         - type: movement_controller

--- a/opencda/scenario_testing/config_yaml/default.yaml
+++ b/opencda/scenario_testing/config_yaml/default.yaml
@@ -166,6 +166,7 @@ vehicle_base:
     communication_range: 35
   behavior_services:
     - type: self_informer
+    - type: default_movement_request
     - type: movement_controller
 
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -304,6 +304,16 @@ _install_stub(
 )
 
 
+# Stubbing opencda.core.application.behavior.services above blocks the package's
+# auto-discovery (which would otherwise need carla at import time). The services
+# used by tests must therefore be imported explicitly so their @BehaviorServiceRegistry.register
+# decorators run.
+import importlib as _importlib  # noqa: E402
+
+_importlib.import_module("opencda.core.application.behavior.services.movement_controller")
+_importlib.import_module("opencda.core.application.behavior.services.default_movement_request")
+
+
 # Static state reset fixtures
 @pytest.fixture(autouse=True)
 def reset_vehicle_manager_state():
@@ -351,7 +361,10 @@ def minimal_vehicle_config():
         "v2x": {},
         "safety_manager": {},
         "platoon": {},
-        "behavior_services": [{"type": "movement_controller"}],
+        "behavior_services": [
+            {"type": "default_movement_request"},
+            {"type": "movement_controller"},
+        ],
     }
 
 

--- a/test/test_vehicle_manager.py
+++ b/test/test_vehicle_manager.py
@@ -216,7 +216,7 @@ def test_run_step_with_data_dumper(mocker, minimal_vehicle_config, mock_cav_worl
     deps["agent"].run_step.return_value = (1.0, "p")
     deps["controller"].run_step.return_value = "ctrl"
 
-    vm.run_step(target_speed=2.0)
+    vm.run_step()
     deps["dumper"].run_step.assert_called_once_with(deps["perception"], deps["localizer"], deps["agent"])
 
 
@@ -352,7 +352,7 @@ def test_run_step_agent_failure_propagates_and_skips_controller(mocker, minimal_
     deps["agent"].run_step.side_effect = RuntimeError("planner failed")
 
     with pytest.raises(RuntimeError, match="planner failed"):
-        vm.run_step(target_speed=5.0)
+        vm.run_step()
 
     deps["map_manager"].run_step.assert_called_once_with()
     deps["controller"].run_step.assert_not_called()
@@ -380,6 +380,6 @@ def test_run_step_controller_failure_propagates_and_skips_data_dump(mocker, mini
 
     deps["dumper"].reset_mock()
     with pytest.raises(RuntimeError, match="control failed"):
-        vm.run_step(target_speed=5.0)
+        vm.run_step()
 
     deps["dumper"].run_step.assert_not_called()


### PR DESCRIPTION
## Summary

<!-- What does this PR change? Why is it needed? -->
Extract the per-tick MovementControllerRequestMessage construction from VehicleManager.run_step into a dedicated behavior service. Previously the message that drove MovementController.process was hardcoded inside run_step, mixing transport-message assembly with the simulation step entry point. Moving it into a proper behavior service makes the fallback control input explicit, configurable per scenario via YAML, and consistent with the rest of the behavior-service architecture (self_informer, aim_client, etc.).

## Related issue

<!-- Use Closes #123 only if this PR fully resolves the issue. -->

## Changes

- New behavior service default_movement_request — priority=3, emits one TransportMessage[MovementControllerRequestMessage] with target_speed=None, target_location=None per tick to the local movement_controller. Lower priority than aim_client (20) so its default is appended to the queue first and overridden by real control commands via MovementController.process taking valid_messages[-1].
- VehicleManager.run_step — removed the inline TransportMessage/MovementControllerRequestMessage construction and the now-unused target_speed parameter (all callers in scenario.py already passed only messages=...). Dropped the corresponding import.
- Added - type: default_movement_request to scenario configs that use movement_controller: default.yaml, aim_check.yaml, codriving_check.yaml. Without this, movement_controller would receive zero requests and the vehicle would not move.

## Validation

<!-- How was this tested or validated? -->

- [x] Simulation run
- [x] Manual verification
- [ ] Not applicable

## Checklist

- [x] Linked the related issue
- [x] Kept the PR focused and reviewable
- [ ] Updated documentation if needed
- [ ] Added or updated validation steps if needed
