### PR TITLE
[scripts] Add CARLA-to-SUMO map conversion utility scripts

### DIFF
--- a/.github/workflows/requirements/requirements-ci.txt
+++ b/.github/workflows/requirements/requirements-ci.txt
@@ -1,6 +1,8 @@
 # Minimal dependencies to run the current unit tests fast in CI/act.
 # Add here only what tests truly need.
 
+
+lxml==6.1.1
 # headless plotting
 matplotlib==3.11.0
 

--- a/opencda/scenario_testing/utils/get_spectator_position.py
+++ b/opencda/scenario_testing/utils/get_spectator_position.py
@@ -1,10 +1,27 @@
-import carla
+import argparse
 
-client = carla.Client("carla", 2000)
-world = client.get_world()
 
-spectator = world.get_spectator()
-location = spectator.get_transform().location
-rotation = spectator.get_transform().rotation
-print(f"Location: {location.x:.2f}, {location.y:.2f}, {location.z:.2f},")
-print(f"Rotation: {rotation.pitch:.2f}, {rotation.yaw:.2f}, {rotation.roll:.2f}")
+def arg_parse() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Print the current CARLA spectator transform.")
+    parser.add_argument("--carla-host", type=str, default="carla", help="IP address or hostname of the CARLA server (default: 'carla')")
+    parser.add_argument("--carla-timeout", type=float, default=30.0, help="Timeout of the CARLA server response in seconds (default: 30.0)")
+    return parser.parse_args()
+
+
+def main() -> None:
+    opt = arg_parse()
+    import carla
+
+    client = carla.Client(opt.carla_host, 2000)
+    client.set_timeout(opt.carla_timeout)
+    world = client.get_world()
+
+    spectator = world.get_spectator()
+    location = spectator.get_transform().location
+    rotation = spectator.get_transform().rotation
+    print(f"Location: {location.x:.2f}, {location.y:.2f}, {location.z:.2f},")
+    print(f"Rotation: {rotation.pitch:.2f}, {rotation.yaw:.2f}, {rotation.roll:.2f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/opencda/scenario_testing/utils/set_spectator_position.py
+++ b/opencda/scenario_testing/utils/set_spectator_position.py
@@ -1,11 +1,28 @@
-import carla
+import argparse
 
-client = carla.Client("carla", 2000)
-world = client.get_world()
 
-spectator = world.get_spectator()
+def arg_parse() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Set the CARLA spectator location from stdin.")
+    parser.add_argument("--carla-host", type=str, default="carla", help="IP address or hostname of the CARLA server (default: 'carla')")
+    parser.add_argument("--carla-timeout", type=float, default=30.0, help="Timeout of the CARLA server response in seconds (default: 30.0)")
+    return parser.parse_args()
 
-x, y, z = map(float, input().split(","))
-location = carla.Location(x=x, y=y, z=z)
-rotation = carla.Rotation(pitch=0, yaw=-180, roll=0)
-spectator.set_transform(carla.Transform(location, rotation))
+
+def main() -> None:
+    opt = arg_parse()
+    import carla
+
+    client = carla.Client(opt.carla_host, 2000)
+    client.set_timeout(opt.carla_timeout)
+    world = client.get_world()
+
+    spectator = world.get_spectator()
+
+    x, y, z = map(float, input().split(","))
+    location = carla.Location(x=x, y=y, z=z)
+    rotation = carla.Rotation(pitch=0, yaw=-180, roll=0)
+    spectator.set_transform(carla.Transform(location, rotation))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/get_spectator_position.py
+++ b/scripts/get_spectator_position.py
@@ -3,7 +3,8 @@ import argparse
 
 def arg_parse() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Print the current CARLA spectator transform.")
-    parser.add_argument("--carla-host", type=str, default="carla", help="IP address or hostname of the CARLA server (default: 'carla')")
+    parser.add_argument("--carla-host", type=str, default="localhost", help="IP address or hostname of the CARLA server (default: 'localhost')")
+    parser.add_argument("--carla-port", "--port", dest="carla_port", type=int, default=2000, help="Port of the CARLA server (default: 2000)")
     parser.add_argument("--carla-timeout", type=float, default=30.0, help="Timeout of the CARLA server response in seconds (default: 30.0)")
     return parser.parse_args()
 
@@ -12,7 +13,7 @@ def main() -> None:
     opt = arg_parse()
     import carla
 
-    client = carla.Client(opt.carla_host, 2000)
+    client = carla.Client(opt.carla_host, opt.carla_port)
     client.set_timeout(opt.carla_timeout)
     world = client.get_world()
 

--- a/scripts/netconvert_carla.py
+++ b/scripts/netconvert_carla.py
@@ -1,8 +1,4 @@
-"""
-Script to generate sumo nets based on opendrive files. Internally,
-it uses netconvert to generatet he net and inserts, manually, the traffic
-light landmarks retrieved from the opendrive.
-"""
+"""Generate a SUMO network from a local OpenDRIVE file."""
 
 from __future__ import annotations
 
@@ -19,6 +15,38 @@ import os
 import sys
 
 
+DEFAULT_OUTPUT_FILE = "net.net.xml"
+DEFAULT_GUESS_TLS = False
+DEFAULT_CARLA_HOST = "localhost"
+DEFAULT_CARLA_PORT = 2000
+DEFAULT_CARLA_TIMEOUT = 30.0
+DEFAULT_CARLA_MAP_NAME: str | None = None
+
+SUMO_HOME_ENVIRONMENT_VARIABLE = "SUMO_HOME"
+SUMO_TOOLS_DIRECTORY = "tools"
+NETCONVERT_EXECUTABLE = "netconvert"
+NETCONVERT_CURVE_RESOLUTION = 1
+NETCONVERT_TRUE_VALUE = "true"
+OPENDRIVE_TYPE_FILE = "data/opendrive_netconvert.typ.xml"
+TRAFFIC_LIGHT_LANDMARK_TYPE = "1000001"
+TEMPORARY_CARLA_MAP_NAME = "carla_map"
+OPENDRIVE_FILE_EXTENSION = ".xodr"
+SUMO_NET_FILE_EXTENSION = ".net.xml"
+TEXT_ENCODING = "utf-8"
+XML_ENCODING = "UTF-8"
+XML_DECLARATION = True
+XML_REMOVE_BLANK_TEXT = True
+DEFAULT_PRETTY_PRINT = False
+CARLA_MAP_PARSER_NAME = "netconvert"
+
+DEFAULT_TL_PROGRAM_ID = "0"
+DEFAULT_TL_OFFSET = 0
+DEFAULT_TL_TYPE = "static"
+DEFAULT_PHASE_MIN_DURATION = -1
+DEFAULT_PHASE_MAX_DURATION = -1
+DEFAULT_PHASE_NAME = ""
+AUTOMATIC_LINK_INDEX = -1
+
 ET: Any = None
 carla: Any = None
 sumolib: Any = None
@@ -31,9 +59,7 @@ OdrToSumoIdsMap: TypeAlias = dict[RoadLaneId, set[RoadLaneId]]
 
 
 def _load_lxml_etree() -> Any:
-    """
-    Load lxml lazily so argparse can run without conversion dependencies.
-    """
+    """Load lxml lazily so CLI help works without conversion dependencies."""
     global ET
     if ET is None:
         import lxml.etree as etree_module
@@ -43,9 +69,7 @@ def _load_lxml_etree() -> Any:
 
 
 def _load_carla() -> Any:
-    """
-    Load CARLA lazily so CLI help works even outside the CARLA environment.
-    """
+    """Load CARLA lazily so CLI help works outside its environment."""
     global carla
     if carla is None:
         import carla as carla_module
@@ -55,15 +79,16 @@ def _load_carla() -> Any:
 
 
 def _load_sumolib() -> Any:
-    """
-    Load sumolib lazily so argparse can run before SUMO_HOME is configured.
-    """
+    """Load sumolib lazily after validating ``SUMO_HOME``."""
     global sumolib
     if sumolib is None:
-        if "SUMO_HOME" not in os.environ:
-            sys.exit("please declare environment variable 'SUMO_HOME'")
+        if SUMO_HOME_ENVIRONMENT_VARIABLE not in os.environ:
+            sys.exit(f"please declare environment variable '{SUMO_HOME_ENVIRONMENT_VARIABLE}'")
 
-        sumo_tools_path = os.path.join(os.environ["SUMO_HOME"], "tools")
+        sumo_tools_path = os.path.join(
+            os.environ[SUMO_HOME_ENVIRONMENT_VARIABLE],
+            SUMO_TOOLS_DIRECTORY,
+        )
         if sumo_tools_path not in sys.path:
             sys.path.append(sumo_tools_path)
 
@@ -74,29 +99,42 @@ def _load_sumolib() -> Any:
 
 
 def _load_conversion_dependencies() -> None:
-    """
-    Load dependencies required by both netconvert and CARLA landmark handling.
-    """
+    """Load dependencies required for OpenDRIVE conversion."""
     _load_lxml_etree()
     _load_carla()
     _load_sumolib()
 
 
-class SumoTopology(object):
+def _map_identifier(map_name: str) -> str:
+    """Return a normalized CARLA map identifier.
+
+    Parameters
+    ----------
+    map_name : str
+        CARLA map name or path.
+
+    Returns
+    -------
+    str
+        Case-folded basename without an extension.
+    """
+    normalized = map_name.replace("\\", "/").rstrip("/").split("/")[-1]
+    return os.path.splitext(normalized)[0].casefold()
+
+
+class SumoTopology:
     """
     This object holds the topology of a sumo net. Internally, the information
     is structured as follows:
 
     Parameters
     ----------
-    topology : {
-            (road_id, lane_id): [(successor_road_id, succesor_lane_id), ...], ...}
-        - paths: {
-            (road_id, lane_id): [
-                ((in_road_id, in_lane_id), (out_road_id, out_lane_id)), ...
-            ], ...}
-        - odr2sumo_ids: {
-            (odr_road_id, odr_lane_id): [(sumo_edge_id, sumo_lane_id), ...], ...}
+    topology : TopologyMap
+        Successor lanes for every standard SUMO lane.
+    paths : PathsMap
+        Incoming and outgoing connections for OpenDRIVE junction lanes.
+    odr2sumo_ids : OdrToSumoIdsMap
+        Mapping from OpenDRIVE road/lane IDs to SUMO edge/lane IDs.
     """
 
     def __init__(self, topology: TopologyMap, paths: PathsMap, odr2sumo_ids: OdrToSumoIdsMap) -> None:
@@ -109,11 +147,21 @@ class SumoTopology(object):
 
     # http://sumo.sourceforge.net/userdoc/Networks/Import/OpenDRIVE.html#dealing_with_lane_sections
     def get_sumo_id(self, odr_road_id: str, odr_lane_id: int, s: float = 0) -> RoadLaneId | None:
-        """
-        Returns the pair (sumo_edge_id, sumo_lane index) corresponding to the
-        provided odr pair. The argument 's' allows selecting the better sumo
-        edge when it has been split into different edges due to different odr
-        lane sections.
+        """Map an OpenDRIVE lane to a SUMO lane.
+
+        Parameters
+        ----------
+        odr_road_id : str
+            OpenDRIVE road identifier.
+        odr_lane_id : int
+            OpenDRIVE lane identifier.
+        s : float
+            Longitudinal coordinate used to select a split lane section.
+
+        Returns
+        -------
+        RoadLaneId or None
+            Matching SUMO edge and lane, if available.
         """
         if (odr_road_id, odr_lane_id) not in self._odr2sumo_ids:
             return None
@@ -135,28 +183,18 @@ class SumoTopology(object):
             return sumo_ids_sorted[index]
 
     def is_junction(self, odr_road_id: str, odr_lane_id: int) -> bool:
-        """
-        Checks whether the provided pair (odr_road_id, odr_lane_id) belongs to
-         a junction.
-        """
+        """Return whether an OpenDRIVE lane belongs to a junction."""
         return (odr_road_id, odr_lane_id) in self._paths
 
     def get_successors(self, sumo_edge_id: str, sumo_lane_index: int) -> list[RoadLaneId]:
-        """
-        Returns the successors (standard roads) of the provided pair
-         (sumo_edge_id, sumo_lane_index)
-        """
+        """Return standard-road successors of a SUMO lane."""
         if self.is_junction(sumo_edge_id, sumo_lane_index):
             return []
 
         return list(self._topology.get((sumo_edge_id, sumo_lane_index), set()))
 
     def get_incoming(self, odr_road_id: str, odr_lane_id: int) -> list[RoadLaneId]:
-        """
-        If the pair (odr_road_id, odr_lane_id) belongs to a junction,
-        returns the incoming edges of the path. Otherwise,
-        return and empty list.
-        """
+        """Return incoming lanes for an OpenDRIVE junction lane."""
         if not self.is_junction(odr_road_id, odr_lane_id):
             return []
 
@@ -164,17 +202,22 @@ class SumoTopology(object):
         return list(result)
 
     def get_path_connectivity(self, odr_road_id: str, odr_lane_id: int) -> list[ConnectionPath]:
-        """
-        Returns incoming and outgoing roads of the
-        pair (odr_road_id, odr_lane_id). If the provided
-        pair not belongs to a junction, returns an empty list.
-        """
+        """Return incoming/outgoing pairs for a junction lane."""
         return list(self._paths.get((odr_road_id, odr_lane_id), set()))
 
 
 def build_topology(sumo_net: sumolib.net.Net) -> SumoTopology:
-    """
-    Builds sumo topology.
+    """Build OpenDRIVE and SUMO lane connectivity mappings.
+
+    Parameters
+    ----------
+    sumo_net : sumolib.net.Net
+        Parsed SUMO network.
+
+    Returns
+    -------
+    SumoTopology
+        Network topology and identifier mappings.
     """
     # --------------------------
     # OpenDrive->Sumo mapped ids
@@ -236,13 +279,19 @@ def build_topology(sumo_net: sumolib.net.Net) -> SumoTopology:
     return SumoTopology(topology, paths, odr2sumo_ids)
 
 
-class SumoTrafficLight(object):
-    """
-    SumoTrafficLight holds all the necessary data to define a traffic light in sumo:
+class SumoTrafficLight:
+    """Store the data required for a SUMO traffic-light program.
 
-        * connections (tlid, from_road, to_road, from_lane, to_lane, link_index).
-        * phases (duration, state, min_dur, max_dur, nex, name).
-        * parameters.
+    Parameters
+    ----------
+    tlid : str
+        SUMO traffic-light identifier.
+    program_id : str
+        SUMO program identifier.
+    offset : int
+        Program offset in seconds.
+    tltype : str
+        SUMO traffic-light controller type.
     """
 
     DEFAULT_DURATION_GREEN_PHASE = 42
@@ -252,7 +301,13 @@ class SumoTrafficLight(object):
     Phase = collections.namedtuple("Phase", "duration state min_dur max_dur next name")
     Connection = collections.namedtuple("Connection", "tlid from_road to_road from_lane to_lane link_index")
 
-    def __init__(self, tlid: str, program_id: str = "0", offset: int = 0, tltype: str = "static") -> None:
+    def __init__(
+        self,
+        tlid: str,
+        program_id: str = DEFAULT_TL_PROGRAM_ID,
+        offset: int = DEFAULT_TL_OFFSET,
+        tltype: str = DEFAULT_TL_TYPE,
+    ) -> None:
         self.id = tlid
         self.program_id = program_id
         self.offset = offset
@@ -264,16 +319,12 @@ class SumoTrafficLight(object):
 
     @staticmethod
     def generate_tl_id(from_edge: str, to_edge: str) -> str:
-        """
-        Generates sumo traffic light id based on the junction connectivity.
-        """
+        """Generate an identifier from connected SUMO edges."""
         return "{}:{}".format(from_edge, to_edge)
 
     @staticmethod
     def generate_default_program(tl: "SumoTrafficLight") -> None:
-        """
-        Generates a default program for the given sumo traffic light
-        """
+        """Generate a default program for a traffic light."""
         incoming_roads = [connection.from_road for connection in tl.connections]
         for road in set(incoming_roads):
             phase_green = ["r"] * len(tl.connections)
@@ -293,26 +344,36 @@ class SumoTrafficLight(object):
         self,
         duration: int,
         state: str,
-        min_dur: int = -1,
-        max_dur: int = -1,
+        min_dur: int = DEFAULT_PHASE_MIN_DURATION,
+        max_dur: int = DEFAULT_PHASE_MAX_DURATION,
         next_phase: int | None = None,
-        name: str = "",
+        name: str = DEFAULT_PHASE_NAME,
     ) -> None:
-        """
-        Adds a new phase.
+        """Add a phase to the traffic-light program.
+
+        Parameters
+        ----------
+        duration : int
+            Phase duration in seconds.
+        state : str
+            SUMO signal-state string.
+        min_dur : int
+            Minimum phase duration.
+        max_dur : int
+            Maximum phase duration.
+        next_phase : int or None
+            Optional next phase index.
+        name : str
+            Optional phase name.
         """
         self.phases.append(SumoTrafficLight.Phase(duration, state, min_dur, max_dur, next_phase, name))
 
     def add_parameter(self, key: int, value: object) -> None:
-        """
-        Adds a new parameter.
-        """
+        """Add a link-index parameter."""
         self.parameters.add((key, value))
 
     def add_connection(self, connection: "SumoTrafficLight.Connection") -> None:
-        """
-        Adds a new connection.
-        """
+        """Add a controlled lane connection."""
         self.connections.add(connection)
 
     def add_landmark(
@@ -323,14 +384,33 @@ class SumoTrafficLight(object):
         to_road: str,
         from_lane: int,
         to_lane: int,
-        link_index: int = -1,
+        link_index: int = AUTOMATIC_LINK_INDEX,
     ) -> bool:
-        """
-        Adds a new landmark.
+        """Associate a CARLA landmark with a SUMO lane connection.
 
-        Returns True if the landmark is successfully included. Otherwise, returns False.
+        Parameters
+        ----------
+        landmark_id : object
+            CARLA landmark identifier.
+        tlid : str
+            SUMO traffic-light identifier.
+        from_road : str
+            Incoming SUMO edge.
+        to_road : str
+            Outgoing SUMO edge.
+        from_lane : int
+            Incoming SUMO lane index.
+        to_lane : int
+            Outgoing SUMO lane index.
+        link_index : int
+            Signal link index, or ``AUTOMATIC_LINK_INDEX`` to allocate one.
+
+        Returns
+        -------
+        bool
+            Whether the landmark was added.
         """
-        if link_index == -1:
+        if link_index == AUTOMATIC_LINK_INDEX:
             link_index = len(self.connections)
 
         def is_same_connection(c1: SumoTrafficLight.Connection, c2: SumoTrafficLight.Connection) -> bool:
@@ -346,6 +426,7 @@ class SumoTrafficLight(object):
         return True
 
     def to_xml(self) -> Any:
+        """Serialize the traffic-light program to an XML element."""
         etree = _load_lxml_etree()
         info = {"id": self.id, "type": self.type, "programID": self.program_id, "offset": str(self.offset)}
 
@@ -358,9 +439,24 @@ class SumoTrafficLight(object):
         return xml_tag
 
 
-def _netconvert_carla_impl(xodr_file: str, output: str, tmpdir: str, guess_tls: bool = False) -> None:
-    """
-    Implements netconvert carla.
+def _netconvert_carla_impl(
+    xodr_file: str,
+    output: str,
+    tmpdir: str,
+    guess_tls: bool = DEFAULT_GUESS_TLS,
+) -> None:
+    """Convert OpenDRIVE and add CARLA traffic-light metadata.
+
+    Parameters
+    ----------
+    xodr_file : str
+        OpenDRIVE input path.
+    output : str
+        SUMO network output path.
+    tmpdir : str
+        Directory for intermediate files.
+    guess_tls : bool
+        Whether to infer all junction traffic-light connections.
     """
     _load_conversion_dependencies()
 
@@ -368,12 +464,12 @@ def _netconvert_carla_impl(xodr_file: str, output: str, tmpdir: str, guess_tls: 
     # netconvert
     # ----------
     basename = os.path.splitext(os.path.basename(xodr_file))[0]
-    tmp_sumo_net = os.path.join(tmpdir, basename + ".net.xml")
+    tmp_sumo_net = os.path.join(tmpdir, basename + SUMO_NET_FILE_EXTENSION)
 
     try:
         basedir = os.path.dirname(os.path.realpath(__file__))
         netconvert_cmd = [
-            "netconvert",
+            NETCONVERT_EXECUTABLE,
             "--opendrive",
             xodr_file,
             "--output-file",
@@ -381,10 +477,10 @@ def _netconvert_carla_impl(xodr_file: str, output: str, tmpdir: str, guess_tls: 
             "--geometry.min-radius.fix",
             "--geometry.remove",
             "--opendrive.curve-resolution",
-            "1",
+            str(NETCONVERT_CURVE_RESOLUTION),
             "--opendrive.import-all-lanes",
         ]
-        type_file = os.path.join(basedir, "data/opendrive_netconvert.typ.xml")
+        type_file = os.path.join(basedir, OPENDRIVE_TYPE_FILE)
         if os.path.exists(type_file):
             netconvert_cmd.extend(["--type-files", type_file])
         else:
@@ -400,15 +496,14 @@ def _netconvert_carla_impl(xodr_file: str, output: str, tmpdir: str, guess_tls: 
                 # Discard loading traffic lights as them will be inserted
                 # manually afterwards.
                 "--tls.discard-loaded",
-                "true",
+                NETCONVERT_TRUE_VALUE,
             ]
         )
         result = subprocess.call(netconvert_cmd)
-    except subprocess.CalledProcessError:
+    except OSError as error:
+        raise RuntimeError("There was an error when executing netconvert.") from error
+    if result != 0:
         raise RuntimeError("There was an error when executing netconvert.")
-    else:
-        if result != 0:
-            raise RuntimeError("There was an error when executing netconvert.")
 
     # --------
     # Sumo net
@@ -419,15 +514,15 @@ def _netconvert_carla_impl(xodr_file: str, output: str, tmpdir: str, guess_tls: 
     # ---------
     # Carla map
     # ---------
-    with open(xodr_file, "r") as f:
-        carla_map = carla.Map("netconvert", str(f.read()))
+    with open(xodr_file, encoding=TEXT_ENCODING) as f:
+        carla_map = carla.Map(CARLA_MAP_PARSER_NAME, str(f.read()))
 
     # ---------
     # Landmarks
     # ---------
     tls: dict[str, SumoTrafficLight] = {}  # {tlsid: SumoTrafficLight}
 
-    landmarks = carla_map.get_all_landmarks_of_type("1000001")
+    landmarks = carla_map.get_all_landmarks_of_type(TRAFFIC_LIGHT_LANDMARK_TYPE)
     for landmark in landmarks:
         if landmark.name == "":
             # This is a workaround to avoid adding traffic lights without controllers.
@@ -500,7 +595,7 @@ def _netconvert_carla_impl(xodr_file: str, output: str, tmpdir: str, guess_tls: 
     # Modify sumo net
     # ---------------
     etree = _load_lxml_etree()
-    parser = etree.XMLParser(remove_blank_text=True)
+    parser = etree.XMLParser(remove_blank_text=XML_REMOVE_BLANK_TEXT)
     tree = etree.parse(tmp_sumo_net, parser)
     root = tree.getroot()
 
@@ -538,22 +633,49 @@ def _netconvert_carla_impl(xodr_file: str, output: str, tmpdir: str, guess_tls: 
     output_dir = os.path.dirname(os.path.abspath(output))
     if output_dir:
         os.makedirs(output_dir, exist_ok=True)
-    tree.write(output, pretty_print=True, encoding="UTF-8", xml_declaration=True)
+    tree.write(
+        output,
+        pretty_print=DEFAULT_PRETTY_PRINT,
+        encoding=XML_ENCODING,
+        xml_declaration=XML_DECLARATION,
+    )
 
 
-def netconvert_carla(xodr_file: str, output: str, guess_tls: bool = False) -> str:
+def netconvert_carla(
+    xodr_file: str,
+    output: str,
+    guess_tls: bool = DEFAULT_GUESS_TLS,
+) -> str:
+    """Generate a SUMO network from an OpenDRIVE file.
+
+    Parameters
+    ----------
+    xodr_file : str
+        OpenDRIVE input path.
+    output : str
+        SUMO network output path.
+    guess_tls : bool
+        Whether to infer all junction traffic-light connections.
+
+    Returns
+    -------
+    str
+        Output path.
     """
-    Generates sumo net.
+    if not os.path.isfile(xodr_file):
+        raise FileNotFoundError(f"OpenDRIVE file does not exist: {xodr_file}")
+    if not xodr_file.lower().endswith(OPENDRIVE_FILE_EXTENSION):
+        raise ValueError(f"OpenDRIVE input must have the {OPENDRIVE_FILE_EXTENSION} extension: {xodr_file}")
 
-        :param xodr_file: opendrive file (*.xodr)
-        :param output: output file (*.net.xml)
-        :param guess_tls: guess traffic lights at intersections.
-        :returns: path to the generated sumo net.
-    """
     tmpdir = None
     try:
         tmpdir = tempfile.mkdtemp()
-        _netconvert_carla_impl(xodr_file, output, tmpdir, guess_tls)
+        _netconvert_carla_impl(
+            xodr_file,
+            output,
+            tmpdir,
+            guess_tls,
+        )
 
     finally:
         if tmpdir is not None and os.path.exists(tmpdir):
@@ -562,64 +684,125 @@ def netconvert_carla(xodr_file: str, output: str, guess_tls: bool = False) -> st
     return output
 
 
-def netconvert_carla_from_opendrive(xodr_content: str, output: str, guess_tls: bool = False, map_name: str = "carla_map") -> str:
-    """
-    Generates a SUMO net from an OpenDRIVE string.
+def netconvert_carla_from_carla(
+    output: str,
+    guess_tls: bool = DEFAULT_GUESS_TLS,
+    carla_host: str = DEFAULT_CARLA_HOST,
+    carla_port: int = DEFAULT_CARLA_PORT,
+    carla_timeout: float = DEFAULT_CARLA_TIMEOUT,
+    carla_map_name: str | None = DEFAULT_CARLA_MAP_NAME,
+) -> str:
+    """Generate a SUMO network from a running CARLA world.
 
-        :param xodr_content: opendrive map content.
-        :param output: output file (*.net.xml)
-        :param guess_tls: guess traffic lights at intersections.
-        :param map_name: name used only for temporary conversion files.
-        :returns: path to the generated sumo net.
-    """
-    tmpdir = None
-    try:
-        tmpdir = tempfile.mkdtemp()
-        tmp_xodr_file = os.path.join(tmpdir, map_name + ".xodr")
-        with open(tmp_xodr_file, "w", encoding="utf-8") as f:
-            f.write(xodr_content)
+    Parameters
+    ----------
+    output : str
+        SUMO network output path.
+    guess_tls : bool
+        Whether to infer all junction traffic-light connections.
+    carla_host : str
+        CARLA server host.
+    carla_port : int
+        CARLA server port.
+    carla_timeout : float
+        CARLA API timeout in seconds.
+    carla_map_name : str or None
+        Map to load when the current map differs.
 
-        _netconvert_carla_impl(tmp_xodr_file, output, tmpdir, guess_tls)
-
-    finally:
-        if tmpdir is not None and os.path.exists(tmpdir):
-            shutil.rmtree(tmpdir)
-
-    return output
-
-
-def get_opendrive_from_carla(carla_host: str, carla_port: int, carla_timeout: float) -> str:
-    """
-    Retrieves the currently loaded CARLA map as OpenDRIVE.
+    Returns
+    -------
+    str
+        Output path.
     """
     carla_module = _load_carla()
     client = carla_module.Client(carla_host, carla_port)
     client.set_timeout(carla_timeout)
     world = client.get_world()
-    return str(world.get_map().to_opendrive())
+    if carla_map_name:
+        current_map_name = str(world.get_map().name)
+        if _map_identifier(current_map_name) != _map_identifier(carla_map_name):
+            logging.info("Loading CARLA map %s (current map: %s)", carla_map_name, current_map_name)
+            world = client.load_world(carla_map_name)
+        else:
+            logging.info("CARLA map %s is already loaded; keeping the current world", current_map_name)
+    xodr_content = str(world.get_map().to_opendrive())
+
+    tmpdir = None
+    try:
+        tmpdir = tempfile.mkdtemp()
+        xodr_file = os.path.join(tmpdir, TEMPORARY_CARLA_MAP_NAME + OPENDRIVE_FILE_EXTENSION)
+        with open(xodr_file, "w", encoding=TEXT_ENCODING) as file:
+            file.write(xodr_content)
+        _netconvert_carla_impl(xodr_file, output, tmpdir, guess_tls)
+    finally:
+        if tmpdir is not None and os.path.exists(tmpdir):
+            shutil.rmtree(tmpdir)
+
+    return output
 
 
-if __name__ == "__main__":
+def _build_argument_parser() -> argparse.ArgumentParser:
+    """Build the command-line parser."""
     argparser = argparse.ArgumentParser(description=__doc__)
-    argparser.add_argument("xodr_file", nargs="?", help="opendrive file (*.xodr)")
-    argparser.add_argument("--output", "-o", default="net.net.xml", type=str, help="output file (default: net.net.xml)")
-    argparser.add_argument("--guess-tls", action="store_true", help="guess traffic lights at intersections (default: False)")
+    argparser.add_argument(
+        "xodr_file",
+        nargs="?",
+        help="OpenDRIVE file (*.xodr)",
+    )
+    argparser.add_argument(
+        "--output",
+        "-o",
+        default=DEFAULT_OUTPUT_FILE,
+        type=str,
+        help="output file (default: %(default)s)",
+    )
+    argparser.add_argument(
+        "--guess-tls",
+        action="store_true",
+        default=DEFAULT_GUESS_TLS,
+        help="guess traffic lights at intersections (default: %(default)s)",
+    )
     argparser.add_argument(
         "--from-carla",
         action="store_true",
-        help="read OpenDRIVE from the currently loaded CARLA map instead of an xodr file",
+        help="read OpenDRIVE from the currently loaded CARLA map",
     )
-    argparser.add_argument("--carla-host", type=str, default="carla", help="IP address or hostname of the CARLA server (default: 'carla')")
-    argparser.add_argument("--carla-port", type=int, default=2000, help="Port of the CARLA server (default: 2000)")
-    argparser.add_argument("--carla-timeout", type=float, default=30.0, help="Timeout of the CARLA server response in seconds (default: 30.0)")
+    argparser.add_argument("--carla-host", default=DEFAULT_CARLA_HOST, help="CARLA server host (default: %(default)s)")
+    argparser.add_argument("--carla-port", type=int, default=DEFAULT_CARLA_PORT, help="CARLA server port (default: %(default)s)")
+    argparser.add_argument("--carla-timeout", type=float, default=DEFAULT_CARLA_TIMEOUT, help="CARLA API timeout in seconds")
+    argparser.add_argument(
+        "--carla-map",
+        default=DEFAULT_CARLA_MAP_NAME,
+        help="load this map only when it is not already active",
+    )
+    return argparser
+
+
+def main() -> None:
+    """Run the command-line network converter."""
+    argparser = _build_argument_parser()
     args = argparser.parse_args()
 
     if args.from_carla:
         if args.xodr_file is not None:
             argparser.error("xodr_file cannot be used together with --from-carla")
-        opendrive = get_opendrive_from_carla(args.carla_host, args.carla_port, args.carla_timeout)
-        netconvert_carla_from_opendrive(opendrive, args.output, args.guess_tls)
+        netconvert_carla_from_carla(
+            args.output,
+            args.guess_tls,
+            carla_host=args.carla_host,
+            carla_port=args.carla_port,
+            carla_timeout=args.carla_timeout,
+            carla_map_name=args.carla_map,
+        )
     else:
         if args.xodr_file is None:
             argparser.error("xodr_file is required unless --from-carla is used")
-        netconvert_carla(args.xodr_file, args.output, args.guess_tls)
+        netconvert_carla(
+            args.xodr_file,
+            args.output,
+            args.guess_tls,
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/netconvert_carla.py
+++ b/scripts/netconvert_carla.py
@@ -4,6 +4,8 @@ it uses netconvert to generatet he net and inserts, manually, the traffic
 light landmarks retrieved from the opendrive.
 """
 
+from __future__ import annotations
+
 import argparse
 import bisect
 import collections
@@ -11,27 +13,73 @@ import logging
 import shutil
 import subprocess
 import tempfile
-from typing import TypeAlias
-
-import lxml.etree as ET
+from typing import Any, TypeAlias
 
 import os
 import sys
 
 
-if "SUMO_HOME" in os.environ:
-    sys.path.append(os.path.join(os.environ["SUMO_HOME"], "tools"))
-else:
-    sys.exit("please declare environment variable 'SUMO_HOME'")
-
-import carla
-import sumolib
+ET: Any = None
+carla: Any = None
+sumolib: Any = None
 
 RoadLaneId: TypeAlias = tuple[str, int]
 ConnectionPath: TypeAlias = tuple[RoadLaneId, RoadLaneId]
 TopologyMap: TypeAlias = dict[RoadLaneId, set[RoadLaneId]]
 PathsMap: TypeAlias = dict[RoadLaneId, set[ConnectionPath]]
 OdrToSumoIdsMap: TypeAlias = dict[RoadLaneId, set[RoadLaneId]]
+
+
+def _load_lxml_etree() -> Any:
+    """
+    Load lxml lazily so argparse can run without conversion dependencies.
+    """
+    global ET
+    if ET is None:
+        import lxml.etree as etree_module
+
+        ET = etree_module
+    return ET
+
+
+def _load_carla() -> Any:
+    """
+    Load CARLA lazily so CLI help works even outside the CARLA environment.
+    """
+    global carla
+    if carla is None:
+        import carla as carla_module
+
+        carla = carla_module
+    return carla
+
+
+def _load_sumolib() -> Any:
+    """
+    Load sumolib lazily so argparse can run before SUMO_HOME is configured.
+    """
+    global sumolib
+    if sumolib is None:
+        if "SUMO_HOME" not in os.environ:
+            sys.exit("please declare environment variable 'SUMO_HOME'")
+
+        sumo_tools_path = os.path.join(os.environ["SUMO_HOME"], "tools")
+        if sumo_tools_path not in sys.path:
+            sys.path.append(sumo_tools_path)
+
+        import sumolib as sumolib_module
+
+        sumolib = sumolib_module
+    return sumolib
+
+
+def _load_conversion_dependencies() -> None:
+    """
+    Load dependencies required by both netconvert and CARLA landmark handling.
+    """
+    _load_lxml_etree()
+    _load_carla()
+    _load_sumolib()
 
 
 class SumoTopology(object):
@@ -297,14 +345,15 @@ class SumoTrafficLight(object):
         self.add_parameter(link_index, landmark_id)
         return True
 
-    def to_xml(self) -> ET._Element:
+    def to_xml(self) -> Any:
+        etree = _load_lxml_etree()
         info = {"id": self.id, "type": self.type, "programID": self.program_id, "offset": str(self.offset)}
 
-        xml_tag = ET.Element("tlLogic", info)
+        xml_tag = etree.Element("tlLogic", info)
         for phase in self.phases:
-            ET.SubElement(xml_tag, "phase", {"state": phase.state, "duration": str(phase.duration)})
+            etree.SubElement(xml_tag, "phase", {"state": phase.state, "duration": str(phase.duration)})
         for parameter in sorted(self.parameters, key=lambda parameter: parameter[0]):
-            ET.SubElement(xml_tag, "param", {"key": "linkSignalID:" + str(parameter[0]), "value": str(parameter[1])})
+            etree.SubElement(xml_tag, "param", {"key": "linkSignalID:" + str(parameter[0]), "value": str(parameter[1])})
 
         return xml_tag
 
@@ -313,6 +362,8 @@ def _netconvert_carla_impl(xodr_file: str, output: str, tmpdir: str, guess_tls: 
     """
     Implements netconvert carla.
     """
+    _load_conversion_dependencies()
+
     # ----------
     # netconvert
     # ----------
@@ -321,20 +372,29 @@ def _netconvert_carla_impl(xodr_file: str, output: str, tmpdir: str, guess_tls: 
 
     try:
         basedir = os.path.dirname(os.path.realpath(__file__))
-        result = subprocess.call(
+        netconvert_cmd = [
+            "netconvert",
+            "--opendrive",
+            xodr_file,
+            "--output-file",
+            tmp_sumo_net,
+            "--geometry.min-radius.fix",
+            "--geometry.remove",
+            "--opendrive.curve-resolution",
+            "1",
+            "--opendrive.import-all-lanes",
+        ]
+        type_file = os.path.join(basedir, "data/opendrive_netconvert.typ.xml")
+        if os.path.exists(type_file):
+            netconvert_cmd.extend(["--type-files", type_file])
+        else:
+            logging.warning(
+                "SUMO OpenDRIVE type file was not found at %s. Running netconvert without custom type definitions.",
+                type_file,
+            )
+
+        netconvert_cmd.extend(
             [
-                "netconvert",
-                "--opendrive",
-                xodr_file,
-                "--output-file",
-                tmp_sumo_net,
-                "--geometry.min-radius.fix",
-                "--geometry.remove",
-                "--opendrive.curve-resolution",
-                "1",
-                "--opendrive.import-all-lanes",
-                "--type-files",
-                os.path.join(basedir, "data/opendrive_netconvert.typ.xml"),
                 # Necessary to link odr and sumo ids.
                 "--output.original-names",
                 # Discard loading traffic lights as them will be inserted
@@ -343,6 +403,7 @@ def _netconvert_carla_impl(xodr_file: str, output: str, tmpdir: str, guess_tls: 
                 "true",
             ]
         )
+        result = subprocess.call(netconvert_cmd)
     except subprocess.CalledProcessError:
         raise RuntimeError("There was an error when executing netconvert.")
     else:
@@ -438,8 +499,9 @@ def _netconvert_carla_impl(xodr_file: str, output: str, tmpdir: str, guess_tls: 
     # ---------------
     # Modify sumo net
     # ---------------
-    parser = ET.XMLParser(remove_blank_text=True)
-    tree = ET.parse(tmp_sumo_net, parser)
+    etree = _load_lxml_etree()
+    parser = etree.XMLParser(remove_blank_text=True)
+    tree = etree.parse(tmp_sumo_net, parser)
     root = tree.getroot()
 
     for tl in tls.values():
@@ -473,6 +535,9 @@ def _netconvert_carla_impl(xodr_file: str, output: str, tmpdir: str, guess_tls: 
                     )
                 )
 
+    output_dir = os.path.dirname(os.path.abspath(output))
+    if output_dir:
+        os.makedirs(output_dir, exist_ok=True)
     tree.write(output, pretty_print=True, encoding="UTF-8", xml_declaration=True)
 
 
@@ -485,22 +550,76 @@ def netconvert_carla(xodr_file: str, output: str, guess_tls: bool = False) -> st
         :param guess_tls: guess traffic lights at intersections.
         :returns: path to the generated sumo net.
     """
+    tmpdir = None
     try:
         tmpdir = tempfile.mkdtemp()
         _netconvert_carla_impl(xodr_file, output, tmpdir, guess_tls)
 
     finally:
-        if os.path.exists(tmpdir):
+        if tmpdir is not None and os.path.exists(tmpdir):
             shutil.rmtree(tmpdir)
 
     return output
 
 
+def netconvert_carla_from_opendrive(xodr_content: str, output: str, guess_tls: bool = False, map_name: str = "carla_map") -> str:
+    """
+    Generates a SUMO net from an OpenDRIVE string.
+
+        :param xodr_content: opendrive map content.
+        :param output: output file (*.net.xml)
+        :param guess_tls: guess traffic lights at intersections.
+        :param map_name: name used only for temporary conversion files.
+        :returns: path to the generated sumo net.
+    """
+    tmpdir = None
+    try:
+        tmpdir = tempfile.mkdtemp()
+        tmp_xodr_file = os.path.join(tmpdir, map_name + ".xodr")
+        with open(tmp_xodr_file, "w", encoding="utf-8") as f:
+            f.write(xodr_content)
+
+        _netconvert_carla_impl(tmp_xodr_file, output, tmpdir, guess_tls)
+
+    finally:
+        if tmpdir is not None and os.path.exists(tmpdir):
+            shutil.rmtree(tmpdir)
+
+    return output
+
+
+def get_opendrive_from_carla(carla_host: str, carla_port: int, carla_timeout: float) -> str:
+    """
+    Retrieves the currently loaded CARLA map as OpenDRIVE.
+    """
+    carla_module = _load_carla()
+    client = carla_module.Client(carla_host, carla_port)
+    client.set_timeout(carla_timeout)
+    world = client.get_world()
+    return str(world.get_map().to_opendrive())
+
+
 if __name__ == "__main__":
     argparser = argparse.ArgumentParser(description=__doc__)
-    argparser.add_argument("xodr_file", help="opendrive file (*.xodr")
+    argparser.add_argument("xodr_file", nargs="?", help="opendrive file (*.xodr)")
     argparser.add_argument("--output", "-o", default="net.net.xml", type=str, help="output file (default: net.net.xml)")
     argparser.add_argument("--guess-tls", action="store_true", help="guess traffic lights at intersections (default: False)")
+    argparser.add_argument(
+        "--from-carla",
+        action="store_true",
+        help="read OpenDRIVE from the currently loaded CARLA map instead of an xodr file",
+    )
+    argparser.add_argument("--carla-host", type=str, default="carla", help="IP address or hostname of the CARLA server (default: 'carla')")
+    argparser.add_argument("--carla-port", type=int, default=2000, help="Port of the CARLA server (default: 2000)")
+    argparser.add_argument("--carla-timeout", type=float, default=30.0, help="Timeout of the CARLA server response in seconds (default: 30.0)")
     args = argparser.parse_args()
 
-    netconvert_carla(args.xodr_file, args.output, args.guess_tls)
+    if args.from_carla:
+        if args.xodr_file is not None:
+            argparser.error("xodr_file cannot be used together with --from-carla")
+        opendrive = get_opendrive_from_carla(args.carla_host, args.carla_port, args.carla_timeout)
+        netconvert_carla_from_opendrive(opendrive, args.output, args.guess_tls)
+    else:
+        if args.xodr_file is None:
+            argparser.error("xodr_file is required unless --from-carla is used")
+        netconvert_carla(args.xodr_file, args.output, args.guess_tls)

--- a/scripts/polyconvert_carla.py
+++ b/scripts/polyconvert_carla.py
@@ -1,0 +1,827 @@
+"""Generate a SUMO polygon file by scanning every streamed CARLA map region."""
+
+from __future__ import annotations
+
+import argparse
+import collections
+import hashlib
+import logging
+import math
+import os
+import re
+import xml.etree.ElementTree as XmlTree
+from typing import Any, Sequence
+
+
+DEFAULT_LABELS = "Buildings,Walls,Vegetation,Foliage"
+DEFAULT_CARLA_HOST = "localhost"
+DEFAULT_CARLA_PORT = 2000
+DEFAULT_CARLA_TIMEOUT = 30.0
+DEFAULT_CARLA_MAP_NAME: str | None = None
+DEFAULT_BOUNDS: tuple[float, float, float, float] | None = None
+DEFAULT_BOUNDS_MARGIN = 0.0
+DEFAULT_BOUNDARY_MARGIN = 150.0
+DEFAULT_MAX_AREA = 5000.0
+DEFAULT_MIN_HEIGHT = 1.0
+DEFAULT_MAX_WALL_THICKNESS = 8.0
+DEFAULT_STREAM_DISTANCE = 2000.0
+DEFAULT_SCAN_STEP = 1800.0
+DEFAULT_SETTLE_TICKS = 2
+DEFAULT_SCAN_ALTITUDE = 500.0
+DEFAULT_PRETTY_PRINT = False
+DEFAULT_VERBOSE = False
+
+OPENDRIVE_PARSE_CHUNK_SIZE = 65536
+MIN_MAP_SPAN = 1.0
+MIN_SETTLE_TICKS = 1
+BBOX_EXTENT_SCALE = 2.0
+MIN_BBOX_DIMENSION = 0.01
+SIGNATURE_PRECISION = 3
+OBJECT_HASH_LENGTH = 16
+MIN_POLYGON_AREA = 0.01
+COORDINATE_PRECISION = 2
+HEIGHT_PRECISION = 2
+POLY_FILL = "1"
+OBJECT_ID_PATTERN = r"[^A-Za-z0-9_.-]+"
+OBJECT_ID_REPLACEMENT = "_"
+FALLBACK_OBJECT_ID = "object"
+HASH_ENCODING = "ascii"
+XML_ENCODING = "UTF-8"
+XML_DECLARATION = True
+XML_SCHEMA_INSTANCE_NS = "http://www.w3.org/2001/XMLSchema-instance"
+SUMO_ADDITIONAL_SCHEMA = "http://sumo.dlr.de/xsd/additional_file.xsd"
+LOG_FORMAT = "%(asctime)s %(levelname)s %(message)s"
+CARLA_STREAM_SETTING_NAMES = (
+    "spectator_as_ego",
+    "tile_stream_distance",
+    "actor_active_distance",
+)
+
+LABEL_ALIASES = {
+    "building": ("Buildings",),
+    "buildings": ("Buildings",),
+    "wall": ("Walls",),
+    "walls": ("Walls",),
+    "vegetation": ("Vegetation", "Foliage"),
+    "foliage": ("Foliage", "Vegetation"),
+    "tree": ("Vegetation", "Foliage"),
+    "trees": ("Vegetation", "Foliage"),
+    "park": ("Vegetation", "Foliage"),
+    "parks": ("Vegetation", "Foliage"),
+}
+
+POLY_STYLE = {
+    "Buildings": ("building", "120,150,180", "1.00"),
+    "Walls": ("wall", "160,160,160", "1.00"),
+    "Vegetation": ("forest", "green", "0.00"),
+    "Foliage": ("forest", "green", "0.00"),
+}
+
+
+def _parse_bounds(value: str) -> tuple[float, float, float, float]:
+    """Parse a CARLA bounding rectangle.
+
+    Parameters
+    ----------
+    value : str
+        Rectangle in ``min_x,min_y,max_x,max_y`` form.
+
+    Returns
+    -------
+    tuple[float, float, float, float]
+        Parsed rectangle coordinates.
+    """
+    parts = [float(part.strip()) for part in value.split(",")]
+    if len(parts) != 4:
+        raise argparse.ArgumentTypeError("bounds must be min_x,min_y,max_x,max_y")
+    min_x, min_y, max_x, max_y = parts
+    if min_x >= max_x or min_y >= max_y:
+        raise argparse.ArgumentTypeError("bounds minimums must be smaller than maximums")
+    return min_x, min_y, max_x, max_y
+
+
+def _sumo_net_location(
+    net_file: str,
+) -> tuple[tuple[float, float], tuple[float, float, float, float]]:
+    """Read coordinate metadata from a SUMO network.
+
+    Parameters
+    ----------
+    net_file : str
+        Path to the SUMO network XML file.
+
+    Returns
+    -------
+    tuple[tuple[float, float], tuple[float, float, float, float]]
+        Network offset and conversion boundary.
+    """
+    if not os.path.isfile(net_file):
+        raise FileNotFoundError(f"SUMO net file does not exist: {net_file}")
+    for event in XmlTree.iterparse(net_file, events=("start",)):
+        element = event[1]
+        if element.tag.rsplit("}", 1)[-1] != "location":
+            continue
+        offset = tuple(float(value) for value in element.attrib["netOffset"].split(","))
+        boundary = tuple(float(value) for value in element.attrib["convBoundary"].split(","))
+        if len(offset) == 2 and len(boundary) == 4:
+            return (offset[0], offset[1]), (boundary[0], boundary[1], boundary[2], boundary[3])
+        break
+    raise ValueError(f"SUMO net {net_file} has no valid location element")
+
+
+def _prepare_output(output: str) -> None:
+    """Validate the output path and create its parent directory.
+
+    Parameters
+    ----------
+    output : str
+        Destination polygon XML path.
+    """
+    output_path = os.path.abspath(output)
+    if os.path.isdir(output_path):
+        raise IsADirectoryError(f"poly output is a directory: {output}")
+    output_dir = os.path.dirname(output_path)
+    if os.path.exists(output_dir) and not os.path.isdir(output_dir):
+        raise NotADirectoryError(f"poly output parent is not a directory: {output_dir}")
+    os.makedirs(output_dir, exist_ok=True)
+    if not os.access(output_dir, os.W_OK):
+        raise PermissionError(f"poly output directory is not writable: {output_dir}")
+
+
+def _opendrive_bounds(xodr: str) -> tuple[float, float, float, float]:
+    """Extract CARLA-coordinate bounds from OpenDRIVE XML.
+
+    Parameters
+    ----------
+    xodr : str
+        OpenDRIVE XML document.
+
+    Returns
+    -------
+    tuple[float, float, float, float]
+        Minimum and maximum CARLA X/Y coordinates.
+    """
+    parser = XmlTree.XMLPullParser(events=("start",))
+    for offset in range(0, len(xodr), OPENDRIVE_PARSE_CHUNK_SIZE):
+        parser.feed(xodr[offset : offset + OPENDRIVE_PARSE_CHUNK_SIZE])
+        for event in parser.read_events():
+            parsed_event: Any = event
+            element = parsed_event[1]
+            if element.tag.rsplit("}", 1)[-1] != "header":
+                continue
+            west = float(element.attrib["west"])
+            east = float(element.attrib["east"])
+            south = float(element.attrib["south"])
+            north = float(element.attrib["north"])
+            return min(west, east), min(-north, -south), max(west, east), max(-north, -south)
+    raise ValueError("OpenDRIVE data has no header with map bounds")
+
+
+def _map_bounds(carla_map: Any) -> tuple[float, float, float, float]:
+    """Determine complete CARLA map bounds.
+
+    Parameters
+    ----------
+    carla_map : Any
+        CARLA map object.
+
+    Returns
+    -------
+    tuple[float, float, float, float]
+        Minimum and maximum CARLA X/Y coordinates.
+    """
+    try:
+        bounds = _opendrive_bounds(str(carla_map.to_opendrive()))
+        if bounds[2] - bounds[0] > MIN_MAP_SPAN and bounds[3] - bounds[1] > MIN_MAP_SPAN:
+            return bounds
+    except (KeyError, TypeError, ValueError, XmlTree.ParseError) as error:
+        logging.warning("Could not read OpenDRIVE bounds: %s. Falling back to spawn points.", error)
+    points = [transform.location for transform in carla_map.get_spawn_points()]
+    if not points:
+        raise ValueError("map has neither usable OpenDRIVE bounds nor spawn points")
+    return (
+        min(point.x for point in points),
+        min(point.y for point in points),
+        max(point.x for point in points),
+        max(point.y for point in points),
+    )
+
+
+def _axis_positions(minimum: float, maximum: float, step: float) -> list[float]:
+    """Build scan coordinates that include both axis boundaries.
+
+    Parameters
+    ----------
+    minimum : float
+        Lower axis boundary.
+    maximum : float
+        Upper axis boundary.
+    step : float
+        Maximum spacing between positions.
+
+    Returns
+    -------
+    list[float]
+        Evenly spaced scan coordinates.
+    """
+    if step <= 0:
+        raise ValueError("scan step must be positive")
+    span = maximum - minimum
+    segment_count = max(1, math.ceil(span / step))
+    return [minimum + span * index / segment_count for index in range(segment_count + 1)]
+
+
+def _scan_positions(bounds: tuple[float, float, float, float], step: float) -> list[tuple[float, float]]:
+    """Build a serpentine scan path over a rectangle.
+
+    Parameters
+    ----------
+    bounds : tuple[float, float, float, float]
+        Minimum and maximum X/Y coordinates.
+    step : float
+        Maximum spacing between adjacent positions.
+
+    Returns
+    -------
+    list[tuple[float, float]]
+        Ordered CARLA X/Y scan positions.
+    """
+    min_x, min_y, max_x, max_y = bounds
+    x_positions = _axis_positions(min_x, max_x, step)
+    y_positions = _axis_positions(min_y, max_y, step)
+    positions: list[tuple[float, float]] = []
+    for row, y in enumerate(y_positions):
+        row_x = x_positions if row % 2 == 0 else reversed(x_positions)
+        positions.extend((x, y) for x in row_x)
+    return positions
+
+
+def _resolve_labels(carla_module: Any, labels: str) -> list[tuple[str, Any]]:
+    """Resolve labels against the installed CARLA API.
+
+    Parameters
+    ----------
+    carla_module : Any
+        Imported CARLA module.
+    labels : str
+        Comma-separated label names or aliases.
+
+    Returns
+    -------
+    list[tuple[str, Any]]
+        Canonical names paired with CARLA enum values.
+    """
+    resolved: list[tuple[str, Any]] = []
+    seen_values: set[str] = set()
+    for requested in (part.strip() for part in labels.split(",")):
+        if not requested:
+            continue
+        candidates = LABEL_ALIASES.get(requested.lower(), (requested,))
+        selected = next(
+            ((name, getattr(carla_module.CityObjectLabel, name)) for name in candidates if hasattr(carla_module.CityObjectLabel, name)),
+            None,
+        )
+        if selected is None:
+            logging.warning("CARLA CityObjectLabel %s is unavailable; skipping it", requested)
+            continue
+        name, value = selected
+        value_key = str(value)
+        if value_key not in seen_values:
+            seen_values.add(value_key)
+            resolved.append((name, value))
+    if not resolved:
+        raise ValueError("none of the requested CityObjectLabel values is available")
+    return resolved
+
+
+def _map_identifier(map_name: str) -> str:
+    """Return a normalized map identifier.
+
+    Parameters
+    ----------
+    map_name : str
+        CARLA map name or path.
+
+    Returns
+    -------
+    str
+        Case-folded basename without an extension.
+    """
+    normalized = map_name.replace("\\", "/").rstrip("/").split("/")[-1]
+    return os.path.splitext(normalized)[0].casefold()
+
+
+def _get_world(client: Any, requested_map_name: str | None) -> Any:
+    """Get the current world and load a map only when necessary.
+
+    Parameters
+    ----------
+    client : Any
+        CARLA client.
+    requested_map_name : str or None
+        Requested map, or ``None`` to keep the current one.
+
+    Returns
+    -------
+    Any
+        Selected CARLA world.
+    """
+    world = client.get_world()
+    if not requested_map_name:
+        return world
+    current_map_name = str(world.get_map().name)
+    if _map_identifier(current_map_name) != _map_identifier(requested_map_name):
+        logging.info("Loading CARLA map %s (current map: %s)", requested_map_name, current_map_name)
+        return client.load_world(requested_map_name)
+    logging.info("CARLA map %s is already loaded; keeping the current world", current_map_name)
+    return world
+
+
+def _box_vertices(box: Any, carla_module: Any) -> list[tuple[float, float, float]]:
+    """Return world-space vertices for a CARLA bounding box."""
+    return [(float(point.x), float(point.y), float(point.z)) for point in box.get_world_vertices(carla_module.Transform())]
+
+
+def _box_passes_filters(
+    box: Any,
+    label: str,
+    min_height: float,
+    max_area: float,
+    max_wall_thickness: float,
+) -> bool:
+    """Check whether a CARLA bounding box passes size filters."""
+    width = BBOX_EXTENT_SCALE * float(box.extent.x)
+    length = BBOX_EXTENT_SCALE * float(box.extent.y)
+    height = BBOX_EXTENT_SCALE * float(box.extent.z)
+    if height < min_height:
+        return False
+    if max_area > 0 and width * length > max_area:
+        return False
+    if label == "Walls" and max_wall_thickness > 0 and min(width, length) > max_wall_thickness:
+        return False
+    return width > MIN_BBOX_DIMENSION and length > MIN_BBOX_DIMENSION
+
+
+def _collect_objects(
+    world: Any,
+    carla_module: Any,
+    labels: str,
+    bounds: tuple[float, float, float, float] | None,
+    bounds_margin: float,
+    stream_distance: float,
+    scan_step: float,
+    settle_ticks: int,
+    timeout: float,
+    scan_altitude: float,
+    min_height: float,
+    max_area: float,
+    max_wall_thickness: float,
+) -> list[dict[str, Any]]:
+    """Scan streamed CARLA tiles and collect unique object boxes.
+
+    Parameters
+    ----------
+    world : Any
+        CARLA world to scan.
+    carla_module : Any
+        Imported CARLA module.
+    labels : str
+        Comma-separated semantic labels.
+    bounds : tuple[float, float, float, float] or None
+        Explicit scan bounds, or ``None`` to detect map bounds.
+    bounds_margin : float
+        Extra margin around scan bounds.
+    stream_distance : float
+        CARLA tile streaming distance.
+    scan_step : float
+        Maximum distance between scan positions.
+    settle_ticks : int
+        Ticks to wait after moving the spectator.
+    timeout : float
+        Timeout for CARLA tick operations.
+    scan_altitude : float
+        Spectator altitude during scanning.
+    min_height : float
+        Minimum object height.
+    max_area : float
+        Maximum footprint area; non-positive disables the limit.
+    max_wall_thickness : float
+        Maximum wall thickness; non-positive disables the limit.
+
+    Returns
+    -------
+    list[dict[str, Any]]
+        Unique objects with labels, identifiers, and box vertices.
+    """
+    if scan_step > stream_distance:
+        logging.warning(
+            "scan step %.1f exceeds stream distance %.1f; unloaded gaps may remain",
+            scan_step,
+            stream_distance,
+        )
+    selected_bounds = bounds or _map_bounds(world.get_map())
+    min_x, min_y, max_x, max_y = selected_bounds
+    scan_bounds = (
+        min_x - bounds_margin,
+        min_y - bounds_margin,
+        max_x + bounds_margin,
+        max_y + bounds_margin,
+    )
+    positions = _scan_positions(scan_bounds, scan_step)
+    resolved_labels = _resolve_labels(carla_module, labels)
+    spectator = world.get_spectator()
+    original_transform = spectator.get_transform()
+    original_settings = world.get_settings()
+    original_values = {name: getattr(original_settings, name) for name in CARLA_STREAM_SETTING_NAMES if hasattr(original_settings, name)}
+    retained: dict[tuple[str, tuple[tuple[float, float, float], ...]], dict[str, Any]] = {}
+    try:
+        settings = world.get_settings()
+        if hasattr(settings, "spectator_as_ego"):
+            settings.spectator_as_ego = True
+        if hasattr(settings, "tile_stream_distance"):
+            settings.tile_stream_distance = stream_distance
+        if hasattr(settings, "actor_active_distance"):
+            settings.actor_active_distance = max(stream_distance, float(settings.actor_active_distance))
+        world.apply_settings(settings)
+        synchronous_mode = bool(settings.synchronous_mode)
+        for index, (x, y) in enumerate(positions, start=1):
+            location = carla_module.Location(x=x, y=y, z=scan_altitude)
+            spectator.set_transform(carla_module.Transform(location, original_transform.rotation))
+            for _ in range(max(MIN_SETTLE_TICKS, settle_ticks)):
+                if synchronous_mode:
+                    world.tick(timeout)
+                else:
+                    world.wait_for_tick(timeout)
+            added: collections.Counter[str] = collections.Counter()
+            for label_name, label_value in resolved_labels:
+                for box in world.get_level_bbs(label_value):
+                    if not _box_passes_filters(box, label_name, min_height, max_area, max_wall_thickness):
+                        continue
+                    vertices = _box_vertices(box, carla_module)
+                    signature_vertices = tuple(
+                        sorted(
+                            (
+                                round(px, SIGNATURE_PRECISION),
+                                round(py, SIGNATURE_PRECISION),
+                                round(pz, SIGNATURE_PRECISION),
+                            )
+                            for px, py, pz in vertices
+                        )
+                    )
+                    signature = (label_name, signature_vertices)
+                    if signature in retained:
+                        continue
+                    digest = hashlib.sha1(repr(signature).encode(HASH_ENCODING)).hexdigest()[:OBJECT_HASH_LENGTH]
+                    retained[signature] = {
+                        "id": f"{label_name.lower()}-{digest}",
+                        "label": label_name,
+                        "vertices": [[px, py, pz] for px, py, pz in vertices],
+                    }
+                    added[label_name] += 1
+            logging.info(
+                "CARLA map scan %s/%s at (%.1f, %.1f): added=%s total=%s",
+                index,
+                len(positions),
+                x,
+                y,
+                dict(added),
+                len(retained),
+            )
+    finally:
+        spectator.set_transform(original_transform)
+        settings = world.get_settings()
+        for name, value in original_values.items():
+            setattr(settings, name, value)
+        world.apply_settings(settings)
+    return sorted(retained.values(), key=lambda item: (item["label"], item["id"]))
+
+
+def _convex_hull(points: list[tuple[float, float]]) -> list[tuple[float, float]]:
+    """Compute a two-dimensional convex hull."""
+    unique = sorted(set(points))
+    if len(unique) <= 2:
+        return unique
+
+    def cross(origin: tuple[float, float], a: tuple[float, float], b: tuple[float, float]) -> float:
+        return (a[0] - origin[0]) * (b[1] - origin[1]) - (a[1] - origin[1]) * (b[0] - origin[0])
+
+    lower: list[tuple[float, float]] = []
+    for point in unique:
+        while len(lower) >= 2 and cross(lower[-2], lower[-1], point) <= 0:
+            lower.pop()
+        lower.append(point)
+    upper: list[tuple[float, float]] = []
+    for point in reversed(unique):
+        while len(upper) >= 2 and cross(upper[-2], upper[-1], point) <= 0:
+            upper.pop()
+        upper.append(point)
+    return lower[:-1] + upper[:-1]
+
+
+def _polygon_area(points: list[tuple[float, float]]) -> float:
+    """Return the absolute area of a polygon."""
+    if len(points) < 3:
+        return 0.0
+    return (
+        abs(
+            sum(
+                points[index][0] * points[(index + 1) % len(points)][1] - points[(index + 1) % len(points)][0] * points[index][1]
+                for index in range(len(points))
+            )
+        )
+        * 0.5
+    )
+
+
+def _minimum_edge_length(points: list[tuple[float, float]]) -> float:
+    """Return the shortest polygon edge length."""
+    return min(
+        math.hypot(
+            points[(index + 1) % len(points)][0] - point[0],
+            points[(index + 1) % len(points)][1] - point[1],
+        )
+        for index, point in enumerate(points)
+    )
+
+
+def _footprint(item: dict[str, Any], offset: tuple[float, float]) -> tuple[list[tuple[float, float]], float]:
+    """Convert CARLA box vertices into a SUMO footprint and height."""
+    vertices = [(float(x), float(y), float(z)) for x, y, z in item["vertices"]]
+    height = max(vertex[2] for vertex in vertices) - min(vertex[2] for vertex in vertices)
+    points = [(vertex[0] + offset[0], -vertex[1] + offset[1]) for vertex in vertices]
+    return _convex_hull(points), height
+
+
+def _intersects_boundary(
+    points: list[tuple[float, float]],
+    boundary: tuple[float, float, float, float],
+    margin: float,
+) -> bool:
+    """Check whether a polygon intersects the expanded SUMO boundary."""
+    min_x, min_y, max_x, max_y = boundary
+    return not (
+        max(point[0] for point in points) < min_x - margin
+        or min(point[0] for point in points) > max_x + margin
+        or max(point[1] for point in points) < min_y - margin
+        or min(point[1] for point in points) > max_y + margin
+    )
+
+
+def _write_poly(
+    objects: Sequence[dict[str, Any]],
+    output: str,
+    offset: tuple[float, float],
+    boundary: tuple[float, float, float, float],
+    labels: str,
+    boundary_margin: float,
+    max_area: float,
+    min_height: float,
+    max_wall_thickness: float,
+) -> str:
+    """Write collected objects as a SUMO polygon XML file.
+
+    Parameters
+    ----------
+    objects : Sequence[dict[str, Any]]
+        Collected CARLA objects.
+    output : str
+        Destination polygon XML path.
+    offset : tuple[float, float]
+        SUMO coordinate offset.
+    boundary : tuple[float, float, float, float]
+        SUMO conversion boundary.
+    labels : str
+        Comma-separated labels to include.
+    boundary_margin : float
+        Margin around the SUMO boundary.
+    max_area : float
+        Maximum polygon area.
+    min_height : float
+        Minimum object height.
+    max_wall_thickness : float
+        Maximum wall thickness.
+
+    Returns
+    -------
+    str
+        Output path.
+    """
+    from lxml import etree
+
+    root = etree.Element(
+        "additional",
+        {f"{{{XML_SCHEMA_INSTANCE_NS}}}noNamespaceSchemaLocation": SUMO_ADDITIONAL_SCHEMA},
+    )
+    requested_labels = {
+        next((name for name in LABEL_ALIASES.get(label.strip().lower(), (label.strip(),)) if name in POLY_STYLE), label.strip())
+        for label in labels.split(",")
+        if label.strip()
+    }
+    indices: collections.Counter[str] = collections.Counter()
+    retained_count = 0
+    for item in objects:
+        label = str(item["label"])
+        if label not in requested_labels:
+            continue
+        footprint, height = _footprint(item, offset)
+        area = _polygon_area(footprint)
+        if len(footprint) < 3 or area <= MIN_POLYGON_AREA or height < min_height:
+            continue
+        if max_area > 0 and area > max_area:
+            continue
+        if label == "Walls" and max_wall_thickness > 0 and _minimum_edge_length(footprint) > max_wall_thickness:
+            continue
+        if not _intersects_boundary(footprint, boundary, boundary_margin):
+            continue
+        poly_type, color, layer = POLY_STYLE[label]
+        source_id = re.sub(OBJECT_ID_PATTERN, OBJECT_ID_REPLACEMENT, str(item["id"])).strip("._-") or FALLBACK_OBJECT_ID
+        shape = " ".join(f"{point[0]:.{COORDINATE_PRECISION}f},{point[1]:.{COORDINATE_PRECISION}f}" for point in footprint)
+        poly = etree.SubElement(
+            root,
+            "poly",
+            {
+                "id": f"{poly_type}_{indices[label]}_{source_id}",
+                "type": poly_type,
+                "color": color,
+                "fill": POLY_FILL,
+                "layer": layer,
+                "shape": shape,
+            },
+        )
+        indices[label] += 1
+        retained_count += 1
+        etree.SubElement(poly, "param", {"key": "carlaLabel", "value": label})
+        etree.SubElement(poly, "param", {"key": "carlaSourceId", "value": str(item["id"])})
+        etree.SubElement(
+            poly,
+            "param",
+            {"key": "carlaHeight", "value": f"{height:.{HEIGHT_PRECISION}f}"},
+        )
+    etree.ElementTree(root).write(
+        output,
+        pretty_print=DEFAULT_PRETTY_PRINT,
+        encoding=XML_ENCODING,
+        xml_declaration=XML_DECLARATION,
+    )
+    logging.info("Wrote %s CARLA environment polygons to %s", retained_count, output)
+    return output
+
+
+def generate_poly(
+    net_file: str,
+    output: str,
+    carla_host: str = DEFAULT_CARLA_HOST,
+    carla_port: int = DEFAULT_CARLA_PORT,
+    carla_timeout: float = DEFAULT_CARLA_TIMEOUT,
+    carla_map_name: str | None = DEFAULT_CARLA_MAP_NAME,
+    labels: str = DEFAULT_LABELS,
+    bounds: tuple[float, float, float, float] | None = DEFAULT_BOUNDS,
+    bounds_margin: float = DEFAULT_BOUNDS_MARGIN,
+    boundary_margin: float = DEFAULT_BOUNDARY_MARGIN,
+    stream_distance: float = DEFAULT_STREAM_DISTANCE,
+    scan_step: float = DEFAULT_SCAN_STEP,
+    settle_ticks: int = DEFAULT_SETTLE_TICKS,
+    scan_altitude: float = DEFAULT_SCAN_ALTITUDE,
+    min_height: float = DEFAULT_MIN_HEIGHT,
+    max_area: float = DEFAULT_MAX_AREA,
+    max_wall_thickness: float = DEFAULT_MAX_WALL_THICKNESS,
+) -> str:
+    """Generate SUMO polygons by scanning a running CARLA world.
+
+    Parameters
+    ----------
+    net_file : str
+        SUMO network used for coordinate conversion and clipping.
+    output : str
+        Destination polygon XML path.
+    carla_host : str
+        CARLA server host.
+    carla_port : int
+        CARLA server port.
+    carla_timeout : float
+        CARLA API timeout in seconds.
+    carla_map_name : str or None
+        Map to load when the current map differs.
+    labels : str
+        Comma-separated CARLA semantic labels.
+    bounds : tuple[float, float, float, float] or None
+        Explicit CARLA scan bounds.
+    bounds_margin : float
+        Extra margin around scan bounds.
+    boundary_margin : float
+        Extra margin around the SUMO boundary.
+    stream_distance : float
+        CARLA tile streaming distance.
+    scan_step : float
+        Maximum distance between scan positions.
+    settle_ticks : int
+        Ticks to wait after each spectator move.
+    scan_altitude : float
+        Spectator altitude during scanning.
+    min_height : float
+        Minimum object height.
+    max_area : float
+        Maximum footprint area.
+    max_wall_thickness : float
+        Maximum wall thickness.
+
+    Returns
+    -------
+    str
+        Output path.
+    """
+    # Validate every filesystem dependency before connecting to CARLA or scanning.
+    offset, boundary = _sumo_net_location(net_file)
+    _prepare_output(output)
+
+    import carla
+
+    client = carla.Client(carla_host, carla_port)
+    client.set_timeout(carla_timeout)
+    world = _get_world(client, carla_map_name)
+    objects = _collect_objects(
+        world,
+        carla,
+        labels,
+        bounds,
+        bounds_margin,
+        stream_distance,
+        scan_step,
+        settle_ticks,
+        carla_timeout,
+        scan_altitude,
+        min_height,
+        max_area,
+        max_wall_thickness,
+    )
+    return _write_poly(
+        objects,
+        output,
+        offset,
+        boundary,
+        labels,
+        boundary_margin,
+        max_area,
+        min_height,
+        max_wall_thickness,
+    )
+
+
+def _build_argument_parser() -> argparse.ArgumentParser:
+    """Build the command-line parser."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--net-file", required=True, help="existing SUMO net file")
+    parser.add_argument("--output", "--poly-output", "-o", required=True, help="output SUMO poly file")
+    parser.add_argument("--carla-host", default=DEFAULT_CARLA_HOST)
+    parser.add_argument("--carla-port", type=int, default=DEFAULT_CARLA_PORT)
+    parser.add_argument("--carla-timeout", type=float, default=DEFAULT_CARLA_TIMEOUT)
+    parser.add_argument("--carla-map", default=DEFAULT_CARLA_MAP_NAME)
+    parser.add_argument("--labels", default=DEFAULT_LABELS)
+    parser.add_argument("--bounds", type=_parse_bounds, default=DEFAULT_BOUNDS)
+    parser.add_argument("--bounds-margin", type=float, default=DEFAULT_BOUNDS_MARGIN)
+    parser.add_argument("--boundary-margin", type=float, default=DEFAULT_BOUNDARY_MARGIN)
+    parser.add_argument("--stream-distance", type=float, default=DEFAULT_STREAM_DISTANCE)
+    parser.add_argument("--scan-step", type=float, default=DEFAULT_SCAN_STEP)
+    parser.add_argument("--settle-ticks", type=int, default=DEFAULT_SETTLE_TICKS)
+    parser.add_argument("--scan-altitude", type=float, default=DEFAULT_SCAN_ALTITUDE)
+    parser.add_argument("--min-height", type=float, default=DEFAULT_MIN_HEIGHT)
+    parser.add_argument("--max-area", type=float, default=DEFAULT_MAX_AREA)
+    parser.add_argument("--max-wall-thickness", type=float, default=DEFAULT_MAX_WALL_THICKNESS)
+    parser.add_argument("--verbose", action="store_true", default=DEFAULT_VERBOSE)
+    return parser
+
+
+def main() -> None:
+    """Run the command-line polygon converter."""
+    parser = _build_argument_parser()
+    args = parser.parse_args()
+    logging.basicConfig(
+        level=logging.INFO if args.verbose else logging.WARNING,
+        format=LOG_FORMAT,
+    )
+    try:
+        generate_poly(
+            args.net_file,
+            args.output,
+            carla_host=args.carla_host,
+            carla_port=args.carla_port,
+            carla_timeout=args.carla_timeout,
+            carla_map_name=args.carla_map,
+            labels=args.labels,
+            bounds=args.bounds,
+            bounds_margin=args.bounds_margin,
+            boundary_margin=args.boundary_margin,
+            stream_distance=args.stream_distance,
+            scan_step=args.scan_step,
+            settle_ticks=args.settle_ticks,
+            scan_altitude=args.scan_altitude,
+            min_height=args.min_height,
+            max_area=args.max_area,
+            max_wall_thickness=args.max_wall_thickness,
+        )
+    except (FileNotFoundError, IsADirectoryError, NotADirectoryError, PermissionError, ValueError, XmlTree.ParseError) as error:
+        parser.error(str(error))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/set_spectator_position.py
+++ b/scripts/set_spectator_position.py
@@ -4,6 +4,7 @@ import argparse
 def arg_parse() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Set the CARLA spectator location from stdin.")
     parser.add_argument("--carla-host", type=str, default="carla", help="IP address or hostname of the CARLA server (default: 'carla')")
+    parser.add_argument("--carla-port", "--port", dest="carla_port", type=int, default=2000, help="Port of the CARLA server (default: 2000)")
     parser.add_argument("--carla-timeout", type=float, default=30.0, help="Timeout of the CARLA server response in seconds (default: 30.0)")
     return parser.parse_args()
 
@@ -12,7 +13,7 @@ def main() -> None:
     opt = arg_parse()
     import carla
 
-    client = carla.Client(opt.carla_host, 2000)
+    client = carla.Client(opt.carla_host, opt.carla_port)
     client.set_timeout(opt.carla_timeout)
     world = client.get_world()
 

--- a/test/test_netconvert_carla.py
+++ b/test/test_netconvert_carla.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from scripts import netconvert_carla as converter
+
+
+def test_netconvert_validates_input_before_loading_dependencies(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError, match="OpenDRIVE file does not exist"):
+        converter.netconvert_carla(str(tmp_path / "missing.xodr"), str(tmp_path / "map.net.xml"))
+
+
+def test_netconvert_rejects_non_xodr_input(tmp_path: Path) -> None:
+    input_file = tmp_path / "map.xml"
+    input_file.write_text("<OpenDRIVE/>", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="must have the .xodr extension"):
+        converter.netconvert_carla(str(input_file), str(tmp_path / "map.net.xml"))
+
+
+class _FakeMap:
+    def __init__(self, name: str, xodr: str = "<OpenDRIVE/>") -> None:
+        self.name = name
+        self.xodr = xodr
+
+    def to_opendrive(self) -> str:
+        return self.xodr
+
+
+class _FakeWorld:
+    def __init__(self, map_name: str) -> None:
+        self.map = _FakeMap(map_name)
+
+    def get_map(self) -> _FakeMap:
+        return self.map
+
+
+class _FakeClient:
+    instance: "_FakeClient"
+
+    def __init__(self, host: str, port: int) -> None:
+        self.host = host
+        self.port = port
+        self.timeout: float | None = None
+        self.world = _FakeWorld("/Game/Carla/Maps/Town13.Town13")
+        self.loaded_maps: list[str] = []
+        _FakeClient.instance = self
+
+    def set_timeout(self, timeout: float) -> None:
+        self.timeout = timeout
+
+    def get_world(self) -> _FakeWorld:
+        return self.world
+
+    def load_world(self, map_name: str) -> _FakeWorld:
+        self.loaded_maps.append(map_name)
+        self.world = _FakeWorld(map_name)
+        return self.world
+
+
+@pytest.mark.parametrize(
+    ("requested_map", "expected_loads"),
+    [("Town13", []), ("Town12", ["Town12"])],
+)
+def test_from_carla_loads_map_only_when_different(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    requested_map: str,
+    expected_loads: list[str],
+) -> None:
+    calls: list[tuple[str, str, str, bool]] = []
+
+    def fake_impl(xodr_file: str, output: str, tmpdir: str, guess_tls: bool) -> None:
+        calls.append((Path(xodr_file).read_text(encoding="utf-8"), output, tmpdir, guess_tls))
+
+    monkeypatch.setattr(converter, "_load_carla", lambda: SimpleNamespace(Client=_FakeClient))
+    monkeypatch.setattr(converter, "_netconvert_carla_impl", fake_impl)
+    output = tmp_path / "map.net.xml"
+
+    result = converter.netconvert_carla_from_carla(
+        str(output),
+        carla_map_name=requested_map,
+    )
+
+    assert result == str(output)
+    assert _FakeClient.instance.loaded_maps == expected_loads
+    assert calls[0][0] == "<OpenDRIVE/>"
+    assert calls[0][3] is converter.DEFAULT_GUESS_TLS
+
+
+def test_argument_parser_defaults_use_module_constants() -> None:
+    parser = converter._build_argument_parser()
+    args = parser.parse_args(["map.xodr"])
+
+    assert args.output == converter.DEFAULT_OUTPUT_FILE
+    assert args.guess_tls is converter.DEFAULT_GUESS_TLS
+    assert args.carla_host == converter.DEFAULT_CARLA_HOST
+    assert args.carla_port == converter.DEFAULT_CARLA_PORT
+    assert args.carla_timeout == converter.DEFAULT_CARLA_TIMEOUT
+    assert args.carla_map == converter.DEFAULT_CARLA_MAP_NAME

--- a/test/test_polyconvert_carla.py
+++ b/test/test_polyconvert_carla.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import xml.etree.ElementTree as XmlTree
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from scripts import polyconvert_carla as converter
+
+
+def test_generate_poly_validates_net_before_importing_carla(tmp_path: Path) -> None:
+    output = tmp_path / "map.poly.xml"
+
+    with pytest.raises(FileNotFoundError, match="SUMO net file does not exist"):
+        converter.generate_poly(str(tmp_path / "missing.net.xml"), str(output))
+
+    assert not output.exists()
+
+
+def test_sumo_net_location_reads_offset_and_boundary(tmp_path: Path) -> None:
+    net_file = tmp_path / "map.net.xml"
+    net_file.write_text(
+        '<net><location netOffset="10.5,-20" convBoundary="0,1,100,200"/></net>',
+        encoding="utf-8",
+    )
+
+    offset, boundary = converter._sumo_net_location(str(net_file))
+
+    assert offset == (10.5, -20.0)
+    assert boundary == (0.0, 1.0, 100.0, 200.0)
+
+
+def test_scan_positions_cover_bounds_in_serpentine_order() -> None:
+    positions = converter._scan_positions((0.0, 0.0, 4.0, 2.0), step=2.0)
+
+    assert positions == [
+        (0.0, 0.0),
+        (2.0, 0.0),
+        (4.0, 0.0),
+        (4.0, 2.0),
+        (2.0, 2.0),
+        (0.0, 2.0),
+    ]
+
+
+class _FakeClient:
+    def __init__(self, current_name: str) -> None:
+        self.current_world = SimpleNamespace(get_map=lambda: SimpleNamespace(name=current_name))
+        self.loaded_maps: list[str] = []
+
+    def get_world(self) -> object:
+        return self.current_world
+
+    def load_world(self, map_name: str) -> object:
+        self.loaded_maps.append(map_name)
+        return SimpleNamespace(get_map=lambda: SimpleNamespace(name=map_name))
+
+
+def test_get_world_keeps_equivalent_current_map() -> None:
+    client = _FakeClient("/Game/Carla/Maps/Town13.Town13")
+
+    world = converter._get_world(client, "Town13")
+
+    assert world is client.current_world
+    assert client.loaded_maps == []
+
+
+def test_get_world_loads_different_map() -> None:
+    client = _FakeClient("Town12")
+
+    converter._get_world(client, "Town13")
+
+    assert client.loaded_maps == ["Town13"]
+
+
+def test_write_poly_transforms_coordinates_and_uses_compact_xml(tmp_path: Path) -> None:
+    output = tmp_path / "map.poly.xml"
+    objects = [
+        {
+            "id": "house 1",
+            "label": "Buildings",
+            "vertices": [
+                [0.0, 0.0, 0.0],
+                [2.0, 0.0, 0.0],
+                [2.0, 3.0, 0.0],
+                [0.0, 3.0, 0.0],
+                [0.0, 0.0, 2.0],
+                [2.0, 0.0, 2.0],
+                [2.0, 3.0, 2.0],
+                [0.0, 3.0, 2.0],
+            ],
+        }
+    ]
+
+    converter._write_poly(
+        objects,
+        str(output),
+        offset=(10.0, 20.0),
+        boundary=(0.0, 0.0, 100.0, 100.0),
+        labels="Buildings",
+        boundary_margin=0.0,
+        max_area=100.0,
+        min_height=1.0,
+        max_wall_thickness=8.0,
+    )
+
+    content = output.read_text(encoding="utf-8")
+    poly = XmlTree.parse(output).getroot().find("poly")
+    assert poly is not None
+    assert poly.attrib["type"] == "building"
+    assert poly.attrib["shape"] == "10.00,17.00 12.00,17.00 12.00,20.00 10.00,20.00"
+    assert "\n  <poly" not in content
+
+
+def test_argument_parser_defaults_use_module_constants() -> None:
+    parser = converter._build_argument_parser()
+    args = parser.parse_args(["--net-file", "map.net.xml", "--output", "map.poly.xml"])
+
+    assert args.carla_host == converter.DEFAULT_CARLA_HOST
+    assert args.carla_port == converter.DEFAULT_CARLA_PORT
+    assert args.carla_timeout == converter.DEFAULT_CARLA_TIMEOUT
+    assert args.carla_map == converter.DEFAULT_CARLA_MAP_NAME
+    assert args.labels == converter.DEFAULT_LABELS
+    assert args.bounds == converter.DEFAULT_BOUNDS
+    assert args.stream_distance == converter.DEFAULT_STREAM_DISTANCE
+    assert args.scan_step == converter.DEFAULT_SCAN_STEP
+    assert args.settle_ticks == converter.DEFAULT_SETTLE_TICKS
+    assert args.scan_altitude == converter.DEFAULT_SCAN_ALTITUDE
+    assert args.min_height == converter.DEFAULT_MIN_HEIGHT
+    assert args.max_area == converter.DEFAULT_MAX_AREA
+    assert args.max_wall_thickness == converter.DEFAULT_MAX_WALL_THICKNESS
+    assert args.verbose is converter.DEFAULT_VERBOSE


### PR DESCRIPTION
## Summary
This PR improves user-facing utility scripts for CARLA/SUMO map preparation.

It moves spectator helper scripts to the top-level `scripts` directory, adds configurable CARLA connection parameters, extends `netconvert_carla.py` so it can generate a SUMO network either from a local OpenDRIVE file or from the currently loaded CARLA world, and adds `polyconvert_carla.py` for generating SUMO polygon files from CARLA static objects.

The change is needed to make CARLA-to-SUMO map preparation easier to run as a standalone workflow and to reduce the amount of manual patching required when preparing SUMO assets for custom CARLA maps.

## Changes
* Moved `get_spectator_position.py` and `set_spectator_position.py` from `opencda/scenario_testing/utils` to the top-level `scripts` directory.
* Added CARLA host, port, and timeout arguments to spectator utility scripts.
* Updated `netconvert_carla.py` with support for generating a SUMO network from a running CARLA world via `--from-carla`.
* Added CARLA map selection and validation logic to avoid reloading the map when the requested map is already active.
* Added `polyconvert_carla.py` for generating SUMO `.poly.xml` files from CARLA static objects and an existing SUMO `.net.xml` file.
* Added tests for `netconvert_carla.py` and `polyconvert_carla.py`.

## Validation
* [x] Scripts run
* [x] Manual verification

Unit-level validation was added for input validation, CARLA map loading behavior, SUMO network metadata parsing, scan position generation, polygon XML output, and CLI parser defaults.