### PR TITLE
[cli] Add CLI version argument

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -87,7 +87,7 @@ Scenario files are loaded from `opencda/scenario_testing/config_yaml`. OpenCDA l
 
 - `-t, --test-scenario`: Define the name of the scenario you want to test. Notice, this only has effect on configurations that are picked up by scenario
 - `--record`: Whether to record and save the simulation process to .log file
-- `-v, --version`: Specify the CARLA simulator version (this does not have any effect in our fork)
+- `-v, --version`: Show the installed OpenCDA version and exit
 - `--free-spectator`: Enable free movement for the spectator camera.
 - `--ticks`: number of simulation ticks to execute
 - `--verbose`: Specifies overall verbosity of output.

--- a/opencda.py
+++ b/opencda.py
@@ -224,7 +224,7 @@ def main() -> None:
     logger = create_logger(level=level, filename=opt.log_file)
     install_traceback_handler(verbose=verbosity != VerbosityLevel.SILENT)
 
-    logger.info(f"OpenCDA Version: {__version__}")
+    logger.info(f"OpenCDA v{__version__}")
 
     cwd = pathlib.Path.cwd()
     default_yaml = config_yaml = cwd / "opencda/scenario_testing/config_yaml/default.yaml"

--- a/opencda.py
+++ b/opencda.py
@@ -11,31 +11,12 @@ from datetime import datetime
 import pathlib
 import logging
 import argparse
-import omegaconf
 import subprocess
-from collections.abc import Callable, Collection
+from collections.abc import Collection
 from types import ModuleType
 from typing import cast
 
-from omegaconf import DictConfig
 from opencda.version import __version__
-
-
-try:
-    from rich.traceback import install as _rich_traceback_install
-except ModuleNotFoundError:
-    rich_traceback_install: Callable[..., object] | None = None
-    print("Rich tracebacks are not available, all CLI configuration regarding tracebacks is ignored.")
-else:
-    rich_traceback_install = _rich_traceback_install
-
-
-try:
-    import coloredlogs
-except ModuleNotFoundError:
-    coloredlogs = None
-    print("could not find coloredlogs module! Your life will look pale.")
-    print("if you are interested in improving it: https://pypi.org/project/coloredlogs")
 
 
 BUILD_COMPLETED_FLAG = "BUILD_COMPLETED_FLAG"
@@ -77,13 +58,17 @@ def create_logger(
     level: int, fmt: str = "- [%(asctime)s][%(name)s] %(message)s", datefmt: str = "%H:%M:%S", filename: str = DEFAULT_LOG_FILENAME
 ) -> logging.Logger:
     logger = logging.getLogger("cavise.opencda")
-    if coloredlogs is not None:
-        coloredlogs.install(level=logging.DEBUG, logger=logger, fmt=fmt, datefmt=datefmt)
-    else:
+    try:
+        import coloredlogs
+    except ModuleNotFoundError:
+        print("could not find coloredlogs module! Your life will look pale.")
+        print("if you are interested in improving it: https://pypi.org/project/coloredlogs")
         handler = logging.StreamHandler(sys.stdout)
         handler.setFormatter(logging.Formatter(fmt=fmt, datefmt=datefmt))
         handler.setLevel(logging.DEBUG)
         logger.addHandler(handler)
+    else:
+        coloredlogs.install(level=logging.DEBUG, logger=logger, fmt=fmt, datefmt=datefmt)
     # Duplicate logs to a JSON file
     json_handler = logging.FileHandler(filename=filename, mode="w", encoding="utf-8")
     json_handler.setLevel(logging.DEBUG)
@@ -111,8 +96,13 @@ def install_traceback_handler(verbose: bool = True, suppress_modules: Collection
 
     joined_strings = set(default_filtered_modules) & set(suppress_modules)
     joined: set[str | ModuleType] = set(joined_strings)
-    if rich_traceback_install is not None:
-        rich_traceback_install(show_locals=verbose, suppress=joined)
+    try:
+        from rich.traceback import install as rich_traceback_install
+    except ModuleNotFoundError:
+        print("Rich tracebacks are not available, all CLI configuration regarding tracebacks is ignored.")
+        return
+
+    rich_traceback_install(show_locals=verbose, suppress=joined)
 
 
 # Parse command line args.
@@ -131,9 +121,7 @@ def arg_parse() -> argparse.Namespace:
     # parser.add_argument("--apply-ml", action='store_true',
     #                     help='whether ml/dl framework such as sklearn/pytorch is needed in the testing. '
     #                          'Set it to true only when you have installed the pytorch/sklearn package.')
-    parser.add_argument(
-        "-v", "--version", type=str, default="0.9.15", help="Specify the CARLA simulator version (this does not have any effect in our fork)"
-    )
+    parser.add_argument("-v", "--version", action="version", version=f"OpenCDA v{__version__}")
     parser.add_argument("--free-spectator", action="store_true", help="Enable free movement for the spectator camera.")
     parser.add_argument("-x", "--xodr", action="store_true", help="Run simulation using a custom map from an XODR file.")
     parser.add_argument("-c", "--cosim", action="store_true", help="Enable co-simulation with SUMO.")
@@ -221,6 +209,9 @@ def check_buld_for_utils(module_path: str, cwd: pathlib.PurePath, verbose: bool,
 
 def main() -> None:
     opt = arg_parse()
+
+    import omegaconf
+    from omegaconf import DictConfig
 
     verbosity = opt.verbose
     if verbosity == VerbosityLevel.FULL:

--- a/opencda/scenario_testing/non_working_scenarios/platoon_stability_2lanefree_carla.py
+++ b/opencda/scenario_testing/non_working_scenarios/platoon_stability_2lanefree_carla.py
@@ -31,7 +31,7 @@ def run_scenario(opt: Any, scenario_params: YamlDict) -> None:
         xodr_path = os.path.join(current_path, "../assets/2lane_freeway_simplified/2lane_freeway_simplified.xodr")
 
         # create scenario manager
-        scenario_manager = sim_api.ScenarioManager(scenario_params, opt.apply_ml, opt.version, xodr_path=xodr_path)
+        scenario_manager = sim_api.ScenarioManager(scenario_params, opt.apply_ml, xodr_path=xodr_path)
 
         if opt.record:
             scenario_manager.client.start_recorder("single_town06_carla.log", True)

--- a/opencda/scenario_testing/scenario.py
+++ b/opencda/scenario_testing/scenario.py
@@ -91,7 +91,6 @@ class Scenario:
             self.scenario_manager = sim_api.CoScenarioManager(
                 scenario_params=scenario_config,
                 apply_ml=opt.apply_ml,
-                carla_version=opt.version,
                 town=town,
                 cav_world=self.cav_world,
                 sumo_file_parent_path=sumo_cfg,
@@ -103,7 +102,6 @@ class Scenario:
             self.scenario_manager = sim_api.ScenarioManager(
                 scenario_params=scenario_config,
                 apply_ml=opt.apply_ml,
-                carla_version=opt.version,
                 xodr_path=xodr_path,
                 town=town,
                 cav_world=self.cav_world,

--- a/opencda/scenario_testing/utils/cosim_api.py
+++ b/opencda/scenario_testing/utils/cosim_api.py
@@ -34,9 +34,6 @@ class CoScenarioManager(ScenarioManager):
     scenario_params : dict
         The dictionary contains all simulation configurations.
 
-    carla_version : str
-        CARLA simulator version, it currently supports 0.9.11 and 0.9.12
-
     xodr_path : str
         The xodr file to the customized map, default: None.
 
@@ -52,7 +49,6 @@ class CoScenarioManager(ScenarioManager):
         self,
         scenario_params: dict[str, Any],
         apply_ml: bool,
-        carla_version: str,
         node_ids: NodeIdMapping,
         xodr_path: str | None = None,
         town: str | None = None,
@@ -61,8 +57,16 @@ class CoScenarioManager(ScenarioManager):
         carla_host: str = "carla",
         carla_timeout: float = 30.0,
     ) -> None:
-        # carla side initializations(partial init is already done in scenario manager
-        super(CoScenarioManager, self).__init__(scenario_params, apply_ml, carla_version, xodr_path, town, cav_world, carla_host)
+        # CARLA side initializations (partial initialization is already done in ScenarioManager).
+        super().__init__(
+            scenario_params=scenario_params,
+            apply_ml=apply_ml,
+            xodr_path=xodr_path,
+            town=town,
+            cav_world=cav_world,
+            carla_host=carla_host,
+            carla_timeout=carla_timeout,
+        )
 
         # these following sets are used to track the vehicles controlled by sumo side
         self._active_actors: set[int] = set()

--- a/opencda/scenario_testing/utils/customized_map_api.py
+++ b/opencda/scenario_testing/utils/customized_map_api.py
@@ -55,16 +55,12 @@ def load_customized_world(xodr_path: str, client: carla.Client) -> carla.World |
         return None
 
 
-def spawn_helper_2lanefree(carla_version: str, coefficient: float) -> carla.Transform:
+def spawn_helper_2lanefree(coefficient: float) -> carla.Transform:
     """
     A helper function to locate the valid spawn point on the merge lane.
 
     Parameters
     ----------
-    carla_version : str
-        The CARLA simulator version. We need this as the map for 0.9.11
-        and 0.9.12 are a little different
-
     coefficient : float
         A single scalar indicating where is the  spawn point, eg. 0.5
         represents the spawn position is in the middle of the merge lane.
@@ -74,9 +70,6 @@ def spawn_helper_2lanefree(carla_version: str, coefficient: float) -> carla.Tran
     transform_point : carla.transform
         The desired spawn points.
     """
-    if carla_version == "0.9.12":
-        coefficient += 0.06
-
     transform_point = carla.Transform(carla.Location(x=-1202.0827, y=458.2501, z=0.3), carla.Rotation(yaw=-20.4866))
 
     begin_point = carla.Transform(carla.Location(x=-16.7102, y=15.3622, z=0.3), carla.Rotation(yaw=-20.4866))

--- a/opencda/scenario_testing/utils/sim_api.py
+++ b/opencda/scenario_testing/utils/sim_api.py
@@ -37,7 +37,7 @@ BlueprintMeta: TypeAlias = Mapping[str, Mapping[str, Any]]
 MapHelper: TypeAlias = Callable[..., carla.Transform]
 
 
-def car_blueprint_filter(blueprint_library: Any, carla_version: str = "0.9.15") -> list[Any]:
+def car_blueprint_filter(blueprint_library: Any) -> list[Any]:
     """
     Exclude the uncommon vehicles from the default CARLA blueprint library
     (i.e., isetta, carlacola, cybertruck, t2).
@@ -47,45 +47,33 @@ def car_blueprint_filter(blueprint_library: Any, carla_version: str = "0.9.15") 
     blueprint_library : carla.blueprint_library
         The blueprint library that contains all models.
 
-    carla_version : str
-        CARLA simulator version, currently support 0.9.11 and 0.9.12. We need
-        this as since CARLA 0.9.12 the blueprint name has been changed a lot.
-
     Returns
     -------
     blueprints : list
         The list of suitable blueprints for vehicles.
     """
 
-    if carla_version == "0.9.15" or carla_version == "0.9.14":
-        logger.info(f"Carla {carla_version} version is selected")
-        blueprints = [
-            blueprint_library.find("vehicle.audi.a2"),
-            blueprint_library.find("vehicle.audi.tt"),
-            blueprint_library.find("vehicle.ford.ambulance"),
-            blueprint_library.find("vehicle.ford.crown"),
-            blueprint_library.find("vehicle.mini.cooper_s_2021"),
-            blueprint_library.find("vehicle.nissan.micra"),
-            blueprint_library.find("vehicle.nissan.patrol"),
-            blueprint_library.find("vehicle.nissan.patrol_2021"),
-            blueprint_library.find("vehicle.tesla.cybertruck"),
-            blueprint_library.find("vehicle.volkswagen.t2"),
-            blueprint_library.find("vehicle.volkswagen.t2_2021"),
-            blueprint_library.find("vehicle.micro.microlino"),
-            blueprint_library.find("vehicle.dodge.charger_police"),
-            blueprint_library.find("vehicle.dodge.charger_police_2020"),
-            blueprint_library.find("vehicle.dodge.charger_2020"),
-            blueprint_library.find("vehicle.lincoln.mkz_2020"),
-            blueprint_library.find("vehicle.seat.leon"),
-            blueprint_library.find("vehicle.nissan.patrol"),
-            blueprint_library.find("vehicle.nissan.micra"),
-        ]
-    else:
-        sys.exit(
-            "Since v0.1.4, we do not support version earlier than "
-            "CARLA v0.9.14. If you want to use early CARLA version including"
-            "0.9.11 and 0.9.12, please use OpenCDA v0.1.3."
-        )
+    blueprints = [
+        blueprint_library.find("vehicle.audi.a2"),
+        blueprint_library.find("vehicle.audi.tt"),
+        blueprint_library.find("vehicle.ford.ambulance"),
+        blueprint_library.find("vehicle.ford.crown"),
+        blueprint_library.find("vehicle.mini.cooper_s_2021"),
+        blueprint_library.find("vehicle.nissan.micra"),
+        blueprint_library.find("vehicle.nissan.patrol"),
+        blueprint_library.find("vehicle.nissan.patrol_2021"),
+        blueprint_library.find("vehicle.tesla.cybertruck"),
+        blueprint_library.find("vehicle.volkswagen.t2"),
+        blueprint_library.find("vehicle.volkswagen.t2_2021"),
+        blueprint_library.find("vehicle.micro.microlino"),
+        blueprint_library.find("vehicle.dodge.charger_police"),
+        blueprint_library.find("vehicle.dodge.charger_police_2020"),
+        blueprint_library.find("vehicle.dodge.charger_2020"),
+        blueprint_library.find("vehicle.lincoln.mkz_2020"),
+        blueprint_library.find("vehicle.seat.leon"),
+        blueprint_library.find("vehicle.nissan.patrol"),
+        blueprint_library.find("vehicle.nissan.micra"),
+    ]
 
     return blueprints
 
@@ -125,9 +113,6 @@ class ScenarioManager:
     scenario_params : dict
         The dictionary contains all simulation configurations.
 
-    carla_version : str
-        CARLA simulator version, it currently supports 0.9.11 and 0.9.12
-
     xodr_path : str
         The xodr file to the customized map, default: None.
 
@@ -160,7 +145,6 @@ class ScenarioManager:
         self,
         scenario_params: ConfigDict,
         apply_ml: bool,
-        carla_version: str,
         xodr_path: str | None = None,
         town: str | None = None,
         cav_world: CavWorld | None = None,
@@ -168,7 +152,6 @@ class ScenarioManager:
         carla_timeout: float = 30.0,
     ) -> None:
         self.scenario_params = scenario_params
-        self.carla_version = carla_version
         self.bp_meta: dict[str, dict[str, Any]] = {}
         self.bp_class_sample_prob: dict[str, float] = {}
 
@@ -327,7 +310,7 @@ class ScenarioManager:
                     ),
                 )
             else:
-                spawn_transform = cast(MapHelper, map_helper)(self.carla_version, *actor_config["spawn_special"])
+                spawn_transform = cast(MapHelper, map_helper)(*actor_config["spawn_special"])
 
             self.spawn_custom_actor(spawn_transform, actor_config, fallback_model)
 
@@ -384,7 +367,7 @@ class ScenarioManager:
                     carla.Rotation(pitch=cav_config["spawn_position"][5], yaw=cav_config["spawn_position"][4], roll=cav_config["spawn_position"][3]),
                 )
             else:
-                spawn_transform = cast(MapHelper, map_helper)(self.carla_version, *cav_config["spawn_special"])
+                spawn_transform = cast(MapHelper, map_helper)(*cav_config["spawn_special"])
 
             vehicle = self.spawn_custom_actor(spawn_transform, cav_config, fallback_model)
 
@@ -545,7 +528,7 @@ class ScenarioManager:
                         ),
                     )
                 else:
-                    spawn_transform = cast(MapHelper, map_helper)(self.carla_version, *cav_config["spawn_special"])
+                    spawn_transform = cast(MapHelper, map_helper)(*cav_config["spawn_special"])
 
                 vehicle = self.spawn_custom_actor(spawn_transform, cav_config, fallback_model)
 
@@ -650,7 +633,7 @@ class ScenarioManager:
 
         blueprint_library = self.world.get_blueprint_library()
         if not self.use_multi_class_bp:
-            ego_vehicle_random_list = car_blueprint_filter(blueprint_library, self.carla_version)
+            ego_vehicle_random_list = car_blueprint_filter(blueprint_library)
         else:
             label_list = list(self.bp_class_sample_prob.keys())
             prob = [self.bp_class_sample_prob[itm] for itm in label_list]
@@ -717,7 +700,7 @@ class ScenarioManager:
         """
         blueprint_library = self.world.get_blueprint_library()
         if not self.use_multi_class_bp:
-            ego_vehicle_random_list = car_blueprint_filter(blueprint_library, self.carla_version)
+            ego_vehicle_random_list = car_blueprint_filter(blueprint_library)
         else:
             label_list = list(self.bp_class_sample_prob.keys())
             prob = [self.bp_class_sample_prob[itm] for itm in label_list]

--- a/test/test_cosim_api.py
+++ b/test/test_cosim_api.py
@@ -246,7 +246,6 @@ def test_coscenario_manager_init_builds_sumo_and_tls_and_bridge_helper(mocker, t
     mgr = CoScenarioManager(
         scenario_params=scenario_params,
         apply_ml=False,
-        carla_version="0.9.15",
         node_ids=node_ids,
         sumo_file_parent_path=str(sumo_dir),
         town=None,
@@ -304,7 +303,6 @@ def test_coscenario_manager_init_missing_sumocfg_raises_assertion(mocker, tmp_pa
         CoScenarioManager(
             scenario_params=scenario_params,
             apply_ml=False,
-            carla_version="0.9.15",
             node_ids=node_ids,
             sumo_file_parent_path=str(sumo_dir),
             town=None,

--- a/test/test_sim_api.py
+++ b/test/test_sim_api.py
@@ -96,7 +96,6 @@ def _make_scenario_manager(mocker, scenario_params=None, traffic_manager=None):
     sm = ScenarioManager(
         scenario_params,
         apply_ml=False,
-        carla_version="0.9.15",
         town=None,
         xodr_path=None,
         cav_world=Mock(),
@@ -106,25 +105,17 @@ def _make_scenario_manager(mocker, scenario_params=None, traffic_manager=None):
     return sm, world, client
 
 
-@pytest.mark.parametrize("version", ["0.9.14", "0.9.15"])
-def test_car_blueprint_filter_supported_versions(version):
+def test_car_blueprint_filter_returns_supported_blueprints():
     from opencda.scenario_testing.utils.sim_api import car_blueprint_filter
 
     blueprint_library = Mock()
     blueprint_library.find.side_effect = lambda name: f"bp:{name}"
 
-    blueprints = car_blueprint_filter(blueprint_library, carla_version=version)
+    blueprints = car_blueprint_filter(blueprint_library)
 
     assert isinstance(blueprints, list)
     assert len(blueprints) == 19
     assert blueprint_library.find.call_count == 19
-
-
-def test_car_blueprint_filter_unsupported_exits():
-    from opencda.scenario_testing.utils.sim_api import car_blueprint_filter
-
-    with pytest.raises(SystemExit):
-        car_blueprint_filter(Mock(), carla_version="0.9.13")
 
 
 def test_multi_class_vehicle_blueprint_filter():
@@ -178,7 +169,7 @@ def test_sync_mode_false_exits(mocker):
     mocker.patch("opencda.scenario_testing.utils.sim_api.carla.Client", return_value=client)
 
     with pytest.raises(SystemExit, match="only supports sync simulation mode"):
-        ScenarioManager(params, apply_ml=False, carla_version="0.9.15", town=None, xodr_path=None, cav_world=Mock(), carla_host="carla")
+        ScenarioManager(params, apply_ml=False, town=None, xodr_path=None, cav_world=Mock(), carla_host="carla")
 
 
 def test_substepping_settings_are_applied(mocker):
@@ -1137,7 +1128,7 @@ def test_create_platoon_manager_uses_map_helper_when_spawn_special_present(mocke
 
     assert platoons == [platoon_manager]
     assert mapping == {501: "platoon-1"}
-    map_helper.assert_called_once_with("0.9.15", 42, 43, 44)
+    map_helper.assert_called_once_with(42, 43, 44)
 
     spawn_custom_actor.assert_called_once()
     assert spawn_custom_actor.call_args.args[0] == expected_transform


### PR DESCRIPTION
## Summary

Simplify the CLI/runtime by removing the unused CARLA version configuration.

## Changes

- Changed -v / --version to print OpenCDA v0.3.0 and exit.
- Deferred optional runtime imports so --version works without scenario dependencies installed.
- Removed carla_version from scenario managers, blueprint filtering, map helpers, scenario calls, and tests.
- Simplified blueprint selection to the current supported CARLA environment.
- Fixed forwarding of carla_timeout from CoScenarioManager to ScenarioManager.

## Validation
- [x] Simulation run
- [x] Manual verification

