### PR TITLE
[feature] Add Sybil attack, Replay attack, Lidar spoofing attack

### DIFF
--- a/docs/md_files/ghost_sybil_attack.md
+++ b/docs/md_files/ghost_sybil_attack.md
@@ -1,0 +1,49 @@
+# Ghost-Sybil Attack
+
+## Overview
+
+The Ghost-Sybil attack injects fake vehicles into the local perception output of selected connected autonomous vehicles (CAVs). The injected vehicles are not real CARLA actors. Instead, they are lightweight actor-like objects that imitate the interface expected by the downstream perception and planning pipeline.
+
+This attack is designed to make a victim vehicle believe that one or more phantom vehicles are present ahead of it. The phantom vehicles are placed along the victim's lane, starting at a configurable distance in front of the victim and separated by a configurable gap.
+
+## How the Attack Works
+
+Each simulation tick, the attack object checks whether the current receiver should be affected. The receiver is affected only if the attack is enabled, the local tick has reached `start_tick`, the attacker vehicle exists, and the receiver is within the attacker's V2X communication range.
+
+If these conditions are satisfied, the attack removes any ghost vehicles injected during a previous tick and creates a new set of fake vehicles. These vehicles are inserted into `objects["vehicles"]`, so the rest of the perception and planning stack treats them as ordinary detected vehicles.
+
+The ghost vehicles are generated relative to the receiver's current road waypoint, not relative to the attacker's physical position. Therefore, this implementation behaves as a perception-level injection attack rather than a true V2X Sybil attack that broadcasts multiple fake sender identities from the attacker's trajectory.
+
+The attacker vehicle can be hidden from its own attack output unless `visible_to_attacker` is enabled.
+
+## Effect on the Victim
+
+The victim receives additional fake vehicles in its perceived vehicle list. Depending on the planner and controller behavior, this may cause the victim to slow down, stop, change its trajectory, or incorrectly reason about traffic density and lane occupancy.
+
+## Additional YAML Configuration Parameters for attack
+
+```yaml
+attack:
+  enabled: true
+  type: ghost_sybil
+  start_tick: 100
+  attacker_vid: cav-100
+  visible_to_attacker: false
+  count: 1
+  ghost_distance: 8.0
+  ghost_gap: 6.0
+  freeze_positions: true
+```
+
+| Parameter | Type | Default | Description |
+|---|---:|---:|---|
+| `enabled` | boolean | `false` | Enables or disables the attack. |
+| `type` | string | `""` | Must be set to `ghost_sybil` for this attack to run. |
+| `start_tick` | integer | `100` | Simulation tick from which the attack starts affecting receivers. |
+| `attacker_vid` | string | `cav-100` | Vehicle ID of the attacker. |
+| `visible_to_attacker` | boolean | `false` | If `false`, the attacker does not receive its own injected ghost vehicles. |
+| `count` | integer | `1` | Number of ghost vehicles injected in front of each affected receiver. |
+| `ghost_distance` | float | `8.0` | Distance in meters from the receiver to the first ghost vehicle. |
+| `ghost_gap` | float | `6.0` | Distance in meters between consecutive ghost vehicles. |
+| `freeze_positions` | boolean | `true` | Parsed by the implementation and stored in the attack object. In the current code, ghost vehicles are rebuilt from the receiver waypoint each tick, so this flag is not actively used to freeze cached positions. |
+```

--- a/docs/md_files/lidar_jamming_attack.md
+++ b/docs/md_files/lidar_jamming_attack.md
@@ -1,0 +1,57 @@
+# LiDAR Jamming Attack
+
+## Overview
+
+The LiDAR jamming attack emulates sensor interference at the perception-output level. Instead of modifying raw LiDAR point clouds, it removes selected perceived objects from the receiver's `objects["vehicles"]` list.
+
+The goal is to make a victim vehicle fail to perceive vehicles located in a configurable jamming region. The attack can operate on all nearby vehicles, vehicles within a distance range, or vehicles inside a forward cone defined by range and field of view.
+
+## How the Attack Works
+
+On each call to `inject()`, the attack increments its local tick counter and checks whether jamming should be applied. Jamming is applied only if the attack is enabled, the current tick is greater than or equal to `start_tick`, the attacker exists, and the receiver is within the attacker's V2X communication range.
+
+If the receiver should be jammed, the attack iterates over `objects["vehicles"]`. For each perceived vehicle, it computes the relative distance from the receiver. Depending on the configured mode, the object is considered inside the jammed region if it is within range, or if it is both within range and inside the receiver's forward field of view.
+
+Objects inside the jamming region are removed according to the configured drop policy. The attack can remove all affected vehicles or limit the number of removed vehicles using `max_drop`. Optionally, it can also clear `objects["traffic_lights"]`.
+
+## Jamming Modes
+
+- `front_cone`: removes objects inside a forward cone in front of the receiver. The cone is controlled by `range_m` and `fov_deg`.
+- `range_only`: removes objects within `range_m`, regardless of angle.
+- `all`: currently behaves like range-based removal after the distance check, so objects must still be within `range_m`.
+
+## Effect on the Victim
+
+The victim may behave as if vehicles in the jammed region do not exist. This can lead to unsafe acceleration, missed collision avoidance, incorrect lane-change decisions, or failure to react to stopped or slow traffic.
+
+## Additional YAML Configuration Parameters for attack
+
+```yaml
+attack:
+  enabled: true
+  type: lidar_jamming
+  start_tick: 100
+  attacker_vid: cav-100
+  visible_to_attacker: false
+  mode: front_cone
+  range_m: 25.0
+  fov_deg: 60.0
+  drop_all: true
+  max_drop: 999
+  drop_traffic_lights: false
+```
+
+| Parameter | Type | Default | Description |
+|---|---:|---:|---|
+| `enabled` | boolean | `false` | Enables or disables the attack. |
+| `type` | string | `""` | Must be set to `lidar_jamming` for this attack to run. |
+| `start_tick` | integer | `100` | Simulation tick from which jamming starts. |
+| `attacker_vid` | string | `cav-100` | Vehicle ID of the attacker. |
+| `visible_to_attacker` | boolean | `false` | If `false`, the attacker is not affected by its own jamming attack. |
+| `mode` | string | `front_cone` | Jamming geometry mode: `front_cone`, `range_only`, or `all`. |
+| `range_m` | float | `25.0` | Maximum distance in meters from the receiver within which perceived vehicles can be removed. |
+| `fov_deg` | float | `60.0` | Field of view angle in degrees for `front_cone` mode. The attack uses half of this angle on each side of the receiver's heading. |
+| `drop_all` | boolean | `true` | If `true`, all vehicles inside the jamming region are removed. |
+| `max_drop` | integer | `999` | Maximum number of vehicles to remove when `drop_all` is `false`. |
+| `drop_traffic_lights` | boolean | `false` | If `true`, the attack also clears perceived traffic lights. |
+```

--- a/docs/md_files/replay_attack.md
+++ b/docs/md_files/replay_attack.md
@@ -1,0 +1,49 @@
+# Replay Attack
+
+## Overview
+
+The replay attack implements a delayed self-replay scenario. The attacker records its own trajectory into a shared buffer and later injects a fake clone of itself into the perception output of nearby victim vehicles.
+
+The injected clone is not a real CARLA actor. It is an actor-like object with a transform, velocity, bounding box, and `type_id` prefix that allows the downstream pipeline to process it as a perceived vehicle.
+
+## How the Attack Works
+
+The attack has two phases: recording and replay.
+
+During the recording phase, only the attack instance belonging to the attacker vehicle records frames. Each recorded frame contains the attacker's position, orientation, and speed. Recording starts at `record_start` and stops once `buffer_size` frames have been stored.
+
+During the replay phase, receivers within the attacker's V2X communication range receive a fake clone. Replay starts at `replay_start`. On each tick, the attack selects a frame from the recorded buffer based on how many ticks have passed since replay started.
+
+The clone is shifted laterally by `lateral_offset` meters relative to the recorded heading. A positive offset places the clone to the left of the recorded direction of travel. While replayed frames are available, the clone receives a velocity vector derived from the recorded speed and yaw. Once the replay index reaches the end of the buffer, the clone freezes at the last recorded position with zero velocity.
+
+The replay buffer is shared between all attack instances through a class-level dictionary keyed by `attacker_vid`, so the attacker records once and all receivers can replay the same trajectory.
+
+## Effect on the Victim
+
+The victim perceives a delayed clone of the attacker, offset into a nearby lane or lateral position. This can create false occupancy, confuse prediction and planning modules, and make the victim react to a vehicle that is no longer physically present at that location.
+
+## Additional YAML Configuration Parameters for attack
+
+```yaml
+attack:
+  enabled: true
+  type: replay
+  attacker_vid: cav-100
+  record_start: 0
+  buffer_size: 100
+  replay_start: 200
+  lateral_offset: 3.5
+  visible_to_attacker: false
+```
+
+| Parameter | Type | Default | Description |
+|---|---:|---:|---|
+| `enabled` | boolean | `false` | Enables or disables the attack. |
+| `type` | string | `""` | Must be set to `replay` for this attack to run. |
+| `attacker_vid` | string | `cav-100` | Vehicle ID of the attacker whose trajectory is recorded and replayed. |
+| `record_start` | integer | `0` | Tick from which the attacker starts recording its trajectory. |
+| `buffer_size` | integer | `100` | Maximum number of recorded trajectory frames. |
+| `replay_start` | integer | `200` | Tick from which victims start receiving the replayed clone. |
+| `lateral_offset` | float | `3.5` | Lateral shift in meters applied to the replayed clone. Positive values move the clone left relative to the recorded heading. |
+| `visible_to_attacker` | boolean | `false` | If `false`, the attacker does not receive its own replay clone. |
+```

--- a/opencda/core/attack/ghost_sybil.py
+++ b/opencda/core/attack/ghost_sybil.py
@@ -1,0 +1,223 @@
+"""
+Ghost-Sybil атака для V2X-симуляции в OpenCDA.
+
+Расположение в проекте: opencda/core/attack/ghost_sybil.py
+
+Идея:
+- VehicleManager не знает деталей атаки.
+- Он только создаёт объект через диспетчер (opencda.core.attack.build_attack)
+  и в каждом тике вызывает:
+    self.attack.tick()
+    objects = self.attack.inject(objects, ego_pos)
+- Если атака выключена в конфиге, диспетчер возвращает NoAttack(),
+  у которого inject() — no-op.
+
+Поведение:
+- Перед получателем (любой CAV в радиусе communication_range от атакующего,
+  кроме самого атакующего, если visible_to_attacker=False) каждый тик
+  начиная с start_tick создаются `count` фантомных ТС, выложенных в линию
+  по полосе с шагом ghost_gap, начиная с расстояния ghost_distance.
+
+NB: ghost'ы строятся от waypoint'а ПОЛУЧАТЕЛЯ, а не атакующего, поэтому
+это перцепционная инъекция, а не настоящая V2X-Sybil. Для V2X-Sybil менять
+надо здесь, в _build_ghosts() — брать позицию от attacker_vm и кэшировать.
+"""
+
+import carla
+
+
+class GhostObstacleVehicle:
+    """Имитация carla-актора, чтобы downstream-код принял её за обычное ТС."""
+
+    def __init__(self, transform, extent_x=2.8, extent_y=1.2, extent_z=1.0, label="ghost"):
+        self.transform = transform
+        self.location = transform.location
+        self.velocity = carla.Vector3D(0.0, 0.0, 0.0)
+        self.bounding_box = type("BBox", (), {})()
+        self.bounding_box.extent = carla.Vector3D(
+            x=extent_x,
+            y=extent_y,
+            z=extent_z,
+        )
+        self.carla_id = -1
+        self.id = -1
+        self.type_id = f"vehicle.ghost.{label}"
+
+    def get_location(self):
+        return self.location
+
+    def get_transform(self):
+        return self.transform
+
+    def get_velocity(self):
+        return self.velocity
+
+
+class GhostSybilAttack:
+    """Подмешивает в objects['vehicles'] фейковые ТС перед получателем."""
+
+    GHOST_TYPE_PREFIX = "vehicle.ghost."
+
+    def __init__(self, vid, attack_cfg, cav_world, carla_map):
+        self.vid = vid
+        self.cav_world = cav_world
+        self.carla_map = carla_map
+
+        self.enabled = (
+            attack_cfg.get("enabled", False)
+            and attack_cfg.get("type", "") == "ghost_sybil"
+        )
+        self.start_tick = int(attack_cfg.get("start_tick", 100))
+        self.attacker_vid = attack_cfg.get("attacker_vid", "cav-100")
+        self.visible_to_attacker = bool(attack_cfg.get("visible_to_attacker", False))
+        self.count = int(attack_cfg.get("count", 1))
+        self.first_distance = float(attack_cfg.get("ghost_distance", 8.0))
+        self.gap = float(attack_cfg.get("ghost_gap", 6.0))
+        self.freeze_positions = bool(attack_cfg.get("freeze_positions", True))
+
+        self.local_tick = 0
+        self._ghost_cache = {}
+
+        print(
+            f"[ATTACK INIT] vid={self.vid}, enabled={self.enabled}, "
+            f"start_tick={self.start_tick}, attacker_vid={self.attacker_vid}"
+        )
+
+    @classmethod
+    def from_v2x_config(cls, vid, v2x_config, cav_world, carla_map):
+        """Используется диспетчером atak. NoAttack возвращается там."""
+        attack_cfg = (v2x_config or {}).get("attack", {}) or {}
+        return cls(vid, attack_cfg, cav_world, carla_map)
+
+    # -------------------------------------------------------------- public API
+
+    def tick(self):
+        self.local_tick += 1
+
+    def inject(self, objects, ego_pos):
+        if not self._should_receive(ego_pos):
+            return objects
+
+        if "vehicles" not in objects:
+            objects["vehicles"] = []
+
+        # очистить ghost'ов с прошлого тика, если они каким-то образом затесались
+        objects["vehicles"] = [
+            obj for obj in objects["vehicles"]
+            if not str(getattr(obj, "type_id", "")).startswith(self.GHOST_TYPE_PREFIX)
+        ]
+
+        # атакующему ничего не показываем
+        if self.vid == self.attacker_vid and not self.visible_to_attacker:
+            print(f"[GHOST SKIP] receiver={self.vid} reason=attacker_hidden")
+            return objects
+
+        ghosts = self._build_ghosts(ego_pos)
+        if not ghosts:
+            print(f"[GHOST ATTACK FAILED] receiver={self.vid} no ghosts generated")
+            return objects
+
+        self._ghost_cache[self.vid] = ghosts
+
+        if self.local_tick == self.start_tick:
+            print(
+                f"[GHOST ATTACK TRIGGERED] receiver={self.vid}, "
+                f"tick={self.local_tick}, ghosts={len(ghosts)}"
+            )
+
+        for g in ghosts:
+            print(
+                f"[GHOST POS] receiver={self.vid}, "
+                f"x={g.get_location().x:.2f}, y={g.get_location().y:.2f}, "
+                f"yaw={g.get_transform().rotation.yaw:.2f}"
+            )
+
+        objects["vehicles"].extend(ghosts)
+        print(
+            f"[GHOST ATTACK APPLIED] receiver={self.vid}, "
+            f"tick={self.local_tick}, vehicles_total={len(objects['vehicles'])}"
+        )
+        return objects
+
+    # --------------------------------------------------------------- internals
+
+    def _get_attacker_vm(self):
+        return self.cav_world.get_vehicle_managers().get(self.attacker_vid)
+
+    def _should_receive(self, ego_pos):
+        print(
+            f"[SHOULD_RECEIVE] vid={self.vid}, "
+            f"attack_enabled={self.enabled}, "
+            f"tick={self.local_tick}, start_tick={self.start_tick}, "
+            f"attacker_vid={self.attacker_vid}"
+        )
+
+        if not self.enabled:
+            print(f"[SHOULD_RECEIVE:NO] vid={self.vid} reason=attack_disabled")
+            return False
+
+        if self.local_tick < self.start_tick:
+            print(f"[SHOULD_RECEIVE:NO] vid={self.vid} reason=before_start_tick")
+            return False
+
+        if self.vid == self.attacker_vid and not self.visible_to_attacker:
+            print(f"[SHOULD_RECEIVE:NO] vid={self.vid} reason=attacker_hidden")
+            return False
+
+        attacker_vm = self._get_attacker_vm()
+        if attacker_vm is None:
+            print(f"[SHOULD_RECEIVE:NO] vid={self.vid} reason=no_attacker_vm")
+            return False
+
+        attacker_pos = attacker_vm.v2x_manager.get_ego_pos()
+        if attacker_pos is None or ego_pos is None:
+            print(f"[SHOULD_RECEIVE:NO] vid={self.vid} reason=no_positions")
+            return False
+
+        distance = attacker_pos.location.distance(ego_pos.location)
+        comm_range = attacker_vm.v2x_manager.communication_range
+        print(
+            f"[SHOULD_RECEIVE:DIST] vid={self.vid}, "
+            f"distance={distance:.2f}, range={comm_range}"
+        )
+
+        if distance > comm_range:
+            print(f"[SHOULD_RECEIVE:NO] vid={self.vid} reason=out_of_range")
+            return False
+
+        print(f"[SHOULD_RECEIVE:YES] vid={self.vid}")
+        return True
+
+    def _build_ghosts(self, ego_pos):
+        ego_wp = self.carla_map.get_waypoint(
+            ego_pos.location,
+            project_to_road=True,
+            lane_type=carla.LaneType.Driving,
+        )
+
+        ghosts = []
+        for i in range(self.count):
+            distance_ahead = self.first_distance + i * self.gap
+            next_wps = ego_wp.next(distance_ahead)
+            if not next_wps:
+                continue
+
+            ghost_tf = next_wps[0].transform
+            ghost = GhostObstacleVehicle(
+                transform=carla.Transform(
+                    carla.Location(
+                        x=ghost_tf.location.x,
+                        y=ghost_tf.location.y,
+                        z=ghost_tf.location.z + 0.2,
+                    ),
+                    carla.Rotation(
+                        pitch=ghost_tf.rotation.pitch,
+                        yaw=ghost_tf.rotation.yaw,
+                        roll=ghost_tf.rotation.roll,
+                    ),
+                ),
+                label=f"sybil_{i + 1}",
+            )
+            ghosts.append(ghost)
+
+        return ghosts

--- a/opencda/core/attack/lidar_jamming.py
+++ b/opencda/core/attack/lidar_jamming.py
@@ -1,0 +1,184 @@
+import math
+
+
+class LidarJammingAttack:
+    """
+    LiDAR jamming emulation at perception-output level.
+
+    Effect:
+    - removes selected perceived vehicles from objects["vehicles"]
+    - can act only on receivers in V2X range of attacker
+    - attacker itself can be excluded from jamming
+    """
+
+    def __init__(self, vehicle_manager, v2x_config):
+        self.vm = vehicle_manager
+
+        attack_cfg = v2x_config.get("attack", {})
+        self.enabled = (
+            attack_cfg.get("enabled", False)
+            and attack_cfg.get("type", "") == "lidar_jamming"
+        )
+
+        self.start_tick = int(attack_cfg.get("start_tick", 100))
+        self.attacker_vid = attack_cfg.get("attacker_vid", "cav-100")
+        self.visible_to_attacker = bool(
+            attack_cfg.get("visible_to_attacker", False)
+        )
+
+        # jamming geometry
+        self.mode = attack_cfg.get("mode", "front_cone")   # front_cone | all | range_only
+        self.range_m = float(attack_cfg.get("range_m", 25.0))
+        self.fov_deg = float(attack_cfg.get("fov_deg", 60.0))
+
+        # drop policy
+        self.drop_all = bool(attack_cfg.get("drop_all", True))
+        self.max_drop = int(attack_cfg.get("max_drop", 999))
+        self.drop_traffic_lights = bool(attack_cfg.get("drop_traffic_lights", False))
+
+        self.local_tick = 0
+
+        print(
+            f"[LIDAR JAM INIT] vid={self.vm.vid}, enabled={self.enabled}, "
+            f"attacker_vid={self.attacker_vid}, start_tick={self.start_tick}, "
+            f"mode={self.mode}, range={self.range_m}, fov={self.fov_deg}"
+        )
+
+    def is_active_now(self):
+        return self.enabled and self.local_tick >= self.start_tick
+
+    def _get_attacker_vm(self):
+        vm_dict = self.vm.cav_world.get_vehicle_managers()
+        return vm_dict.get(self.attacker_vid)
+
+    def _should_jam(self):
+        print(
+            f"[LIDAR JAM SHOULD] vid={self.vm.vid}, "
+            f"enabled={self.enabled}, tick={self.local_tick}, "
+            f"start_tick={self.start_tick}, attacker_vid={self.attacker_vid}"
+        )
+
+        if not self.enabled:
+            print(f"[LIDAR JAM:NO] vid={self.vm.vid} reason=attack_disabled")
+            return False
+
+        if self.local_tick < self.start_tick:
+            print(f"[LIDAR JAM:NO] vid={self.vm.vid} reason=before_start_tick")
+            return False
+
+        if self.vm.vid == self.attacker_vid and not self.visible_to_attacker:
+            print(f"[LIDAR JAM:NO] vid={self.vm.vid} reason=attacker_hidden")
+            return False
+
+        attacker_vm = self._get_attacker_vm()
+        if attacker_vm is None:
+            print(f"[LIDAR JAM:NO] vid={self.vm.vid} reason=no_attacker_vm")
+            return False
+
+        attacker_pos = attacker_vm.v2x_manager.get_ego_pos()
+        my_pos = self.vm.localizer.get_ego_pos()
+
+        if attacker_pos is None or my_pos is None:
+            print(f"[LIDAR JAM:NO] vid={self.vm.vid} reason=no_positions")
+            return False
+
+        distance = attacker_pos.location.distance(my_pos.location)
+        print(
+            f"[LIDAR JAM:DIST] vid={self.vm.vid}, "
+            f"distance={distance:.2f}, range={attacker_vm.v2x_manager.communication_range}"
+        )
+
+        if distance > attacker_vm.v2x_manager.communication_range:
+            print(f"[LIDAR JAM:NO] vid={self.vm.vid} reason=out_of_range")
+            return False
+
+        print(f"[LIDAR JAM:YES] vid={self.vm.vid}")
+        return True
+
+    def _vehicle_in_jam_region(self, ego_pos, obj):
+        """
+        Decide whether a perceived object is affected by jamming.
+        """
+        if not hasattr(obj, "get_location"):
+            return False
+        def _vehicle_in_jam_region(self, ego_pos, obj):
+            # Для dict-объектов из PerceptionManager
+            if isinstance(obj, dict):
+                loc = obj.get("location") or obj.get("carla_location")
+                if loc is None:
+                    return False
+                dx = loc.x - ego_pos.location.x
+                dy = loc.y - ego_pos.location.y
+            elif hasattr(obj, "get_location"):
+                obj_loc = obj.get_location()
+                dx = obj_loc.x - ego_pos.location.x
+                dy = obj_loc.y - ego_pos.location.y
+            else:
+                return False
+        obj_loc = obj.get_location()
+        dx = obj_loc.x - ego_pos.location.x
+        dy = obj_loc.y - ego_pos.location.y
+        dist = math.sqrt(dx * dx + dy * dy)
+
+        if dist > self.range_m:
+            return False
+
+        if self.mode == "all":
+            return True
+
+        if self.mode == "range_only":
+            return True
+
+        # front_cone
+        ego_yaw_rad = math.radians(ego_pos.rotation.yaw)
+        forward_x = math.cos(ego_yaw_rad)
+        forward_y = math.sin(ego_yaw_rad)
+
+        if dist < 1e-6:
+            return True
+
+        dir_x = dx / dist
+        dir_y = dy / dist
+        dot = max(-1.0, min(1.0, forward_x * dir_x + forward_y * dir_y))
+        angle_deg = math.degrees(math.acos(dot))
+
+        return angle_deg <= (self.fov_deg / 2.0)
+
+    def inject(self, objects, ego_pos):
+        self.local_tick += 1
+
+        if not self._should_jam():
+            return objects
+
+        if "vehicles" not in objects:
+            objects["vehicles"] = []
+
+        original = objects["vehicles"]
+        kept = []
+        dropped = []
+
+        for obj in original:
+            if self._vehicle_in_jam_region(ego_pos, obj):
+                if self.drop_all or len(dropped) < self.max_drop:
+                    dropped.append(obj)
+                    continue
+            kept.append(obj)
+
+        objects["vehicles"] = kept
+
+        if self.drop_traffic_lights and "traffic_lights" in objects:
+            objects["traffic_lights"] = []
+
+        print(
+            f"[LIDAR JAM APPLIED] receiver={self.vm.vid}, tick={self.local_tick}, "
+            f"dropped={len(dropped)}, kept={len(kept)}"
+        )
+
+        for obj in dropped[:5]:
+            loc = obj.get_location()
+            print(
+                f"[LIDAR JAM DROP] receiver={self.vm.vid}, "
+                f"x={loc.x:.2f}, y={loc.y:.2f}"
+            )
+
+        return objects

--- a/opencda/core/attack/replay_attack.py
+++ b/opencda/core/attack/replay_attack.py
@@ -1,0 +1,279 @@
+"""
+Replay-атака для V2X-симуляции в OpenCDA.
+
+Расположение: opencda/core/attack/replay_attack.py
+
+Сценарий: delayed self-replay.
+- Атакующий пишет свою траекторию в буфер фиксированного размера.
+- Начиная с replay_start, на каждый тик подмешивает в перцепцию жертв
+  фантомный "клон" самого себя, идущий с задержкой в buffer_size тиков
+  и сдвинутый на lateral_offset метров вбок (соседняя полоса).
+- Когда буфер исчерпан и replay-указатель доходит до конца записи,
+  клон замораживается на последней позиции.
+
+Архитектура зеркальна GhostSybilAttack:
+- from_v2x_config(...) — фабричный метод, вызывается диспетчером
+- VehicleManager в каждом тике вызывает attack.tick() и attack.inject()
+
+Буфер делится между всеми экземплярами ReplayAttack через class-level
+словарь _shared_buffer: запись принадлежит атакующему (его vid),
+проигрывают её все получатели в радиусе.
+"""
+
+import math
+
+import carla
+
+
+class ReplayCloneVehicle:
+    """Имитация carla-актора. В отличие от GhostObstacleVehicle:
+    - скорость ненулевая (берётся из записанного буфера)
+    - id = -2 (чтобы отличать от ghost'ов с id = -1)
+    - type_id = vehicle.replay.* (отдельный префикс)
+    """
+
+    def __init__(self, transform, velocity, extent_x=2.5, extent_y=1.1, extent_z=0.8, label="clone"):
+        self.transform = transform
+        self.location = transform.location
+        self.velocity = velocity
+        self.bounding_box = type("BBox", (), {})()
+        self.bounding_box.extent = carla.Vector3D(
+            x=extent_x,
+            y=extent_y,
+            z=extent_z,
+        )
+        self.carla_id = -2
+        self.id = -2
+        self.type_id = f"vehicle.replay.{label}"
+
+    def get_location(self):
+        return self.location
+
+    def get_transform(self):
+        return self.transform
+
+    def get_velocity(self):
+        return self.velocity
+
+
+class ReplayAttack:
+    """Delayed self-replay атакующего CAV."""
+
+    REPLAY_TYPE_PREFIX = "vehicle.replay."
+
+    # буфер делится между всеми экземплярами:
+    # {attacker_vid: list[frame_dict]}
+    _shared_buffer = {}
+
+    def __init__(self, vid, attack_cfg, cav_world, carla_map):
+        self.vid = vid
+        self.cav_world = cav_world
+        self.carla_map = carla_map
+
+        self.enabled = (
+            attack_cfg.get("enabled", False)
+            and attack_cfg.get("type", "") == "replay"
+        )
+        self.attacker_vid = attack_cfg.get("attacker_vid", "cav-100")
+        self.record_start = int(attack_cfg.get("record_start", 0))
+        self.buffer_size = int(attack_cfg.get("buffer_size", 100))
+        self.replay_start = int(attack_cfg.get("replay_start", 200))
+        self.lateral_offset = float(attack_cfg.get("lateral_offset", 3.5))
+        self.visible_to_attacker = bool(attack_cfg.get("visible_to_attacker", False))
+
+        ReplayAttack._shared_buffer.setdefault(self.attacker_vid, [])
+
+        self.local_tick = 0
+
+        print(
+            f"[REPLAY INIT] vid={self.vid}, enabled={self.enabled}, "
+            f"attacker_vid={self.attacker_vid}, "
+            f"record_start={self.record_start}, buffer_size={self.buffer_size}, "
+            f"replay_start={self.replay_start}, lateral_offset={self.lateral_offset}"
+        )
+
+    @classmethod
+    def from_v2x_config(cls, vid, v2x_config, cav_world, carla_map):
+        attack_cfg = (v2x_config or {}).get("attack", {}) or {}
+        return cls(vid, attack_cfg, cav_world, carla_map)
+
+    @classmethod
+    def reset_buffers(cls):
+        """Очистить буферы между прогонами симуляции в одном процессе."""
+        cls._shared_buffer.clear()
+
+    # -------------------------------------------------------------- public API
+
+    def tick(self):
+        self.local_tick += 1
+        # запись делает только тот экземпляр, что принадлежит атакующему
+        if self.vid == self.attacker_vid:
+            self._record_frame()
+
+    def inject(self, objects, ego_pos):
+        if not self._should_receive(ego_pos):
+            return objects
+
+        if "vehicles" not in objects:
+            objects["vehicles"] = []
+
+        # вычистим клонов с прошлого тика (страховка)
+        objects["vehicles"] = [
+            obj for obj in objects["vehicles"]
+            if not str(getattr(obj, "type_id", "")).startswith(self.REPLAY_TYPE_PREFIX)
+        ]
+
+        clone = self._build_clone()
+        if clone is None:
+            print(f"[REPLAY] receiver={self.vid} reason=buffer_empty")
+            return objects
+
+        objects["vehicles"].append(clone)
+        loc = clone.get_location()
+        v = clone.get_velocity()
+        speed = math.sqrt(v.x * v.x + v.y * v.y + v.z * v.z)
+
+        if self.local_tick == self.replay_start:
+            print(
+                f"[REPLAY TRIGGERED] receiver={self.vid}, "
+                f"tick={self.local_tick}, buffer_size={len(self._buffer())}"
+            )
+
+        print(
+            f"[REPLAY POS] receiver={self.vid}, "
+            f"x={loc.x:.2f}, y={loc.y:.2f}, "
+            f"yaw={clone.get_transform().rotation.yaw:.2f}, speed={speed:.2f}"
+        )
+        return objects
+
+    # --------------------------------------------------------------- recording
+
+    def _buffer(self):
+        return ReplayAttack._shared_buffer.setdefault(self.attacker_vid, [])
+
+    def _record_frame(self):
+        if self.local_tick < self.record_start:
+            return
+        buf = self._buffer()
+        if len(buf) >= self.buffer_size:
+            return  # буфер заполнен, останавливаем запись
+
+        attacker_vm = self.cav_world.get_vehicle_managers().get(self.attacker_vid)
+        if attacker_vm is None:
+            print(
+                f"[REPLAY RECORD SKIP] tick={self.local_tick} "
+                f"reason=no_attacker_vm attacker_vid={self.attacker_vid} "
+                f"known_vids={list(self.cav_world.get_vehicle_managers().keys())}"
+            )
+            return
+        ego_pos = attacker_vm.localizer.get_ego_pos()
+        ego_spd = attacker_vm.localizer.get_ego_spd()
+        if ego_pos is None:
+            print(
+                f"[REPLAY RECORD SKIP] tick={self.local_tick} "
+                f"reason=localizer_returned_none vid={self.vid}"
+            )
+            return
+
+        frame = {
+            "x": ego_pos.location.x,
+            "y": ego_pos.location.y,
+            "z": ego_pos.location.z,
+            "pitch": ego_pos.rotation.pitch,
+            "yaw": ego_pos.rotation.yaw,
+            "roll": ego_pos.rotation.roll,
+            "speed": ego_spd if ego_spd is not None else 0.0,
+        }
+        buf.append(frame)
+
+        if len(buf) == 1:
+            print(f"[REPLAY RECORD START] tick={self.local_tick} attacker={self.attacker_vid}")
+        if len(buf) == self.buffer_size:
+            print(
+                f"[REPLAY RECORD DONE] tick={self.local_tick} "
+                f"attacker={self.attacker_vid} frames={len(buf)}"
+            )
+
+    # ----------------------------------------------------------------- replay
+
+    def _should_receive(self, ego_pos):
+        if not self.enabled:
+            return False
+        if self.local_tick < self.replay_start:
+            return False
+        if self.vid == self.attacker_vid and not self.visible_to_attacker:
+            return False
+
+        attacker_vm = self.cav_world.get_vehicle_managers().get(self.attacker_vid)
+        if attacker_vm is None:
+            print(f"[REPLAY SHOULD_RECEIVE:NO] vid={self.vid} reason=no_attacker_vm")
+            return False
+
+        attacker_pos = attacker_vm.v2x_manager.get_ego_pos()
+        if attacker_pos is None or ego_pos is None:
+            print(
+                f"[REPLAY SHOULD_RECEIVE:NO] vid={self.vid} reason=no_positions "
+                f"attacker_pos={attacker_pos is not None} ego_pos={ego_pos is not None}"
+            )
+            return False
+
+        distance = attacker_pos.location.distance(ego_pos.location)
+        comm_range = attacker_vm.v2x_manager.communication_range
+        if distance > comm_range:
+            print(
+                f"[REPLAY SHOULD_RECEIVE:NO] vid={self.vid} "
+                f"reason=out_of_range distance={distance:.2f} range={comm_range}"
+            )
+            return False
+
+        print(
+            f"[REPLAY SHOULD_RECEIVE:YES] vid={self.vid} "
+            f"tick={self.local_tick} buffer_len={len(self._buffer())}"
+        )
+        return True
+
+    def _build_clone(self):
+        buf = self._buffer()
+        if not buf:
+            return None
+
+        # индекс кадра: сколько тиков прошло с replay_start
+        idx = self.local_tick - self.replay_start
+        if idx < 0:
+            return None
+        if idx >= len(buf):
+            idx = len(buf) - 1  # frozen на последнем кадре
+            frozen = True
+        else:
+            frozen = False
+
+        frame = buf[idx]
+        yaw_rad = math.radians(frame["yaw"])
+        # перпендикуляр к направлению движения (положительный offset = влево по ходу)
+        offset_x = -math.sin(yaw_rad) * self.lateral_offset
+        offset_y = math.cos(yaw_rad) * self.lateral_offset
+
+        clone_tf = carla.Transform(
+            carla.Location(
+                x=frame["x"] + offset_x,
+                y=frame["y"] + offset_y,
+                z=frame["z"],
+            ),
+            carla.Rotation(
+                pitch=frame["pitch"],
+                yaw=frame["yaw"],
+                roll=frame["roll"],
+            ),
+        )
+
+        if frozen:
+            velocity = carla.Vector3D(0.0, 0.0, 0.0)
+        else:
+            speed = frame["speed"]
+            velocity = carla.Vector3D(
+                x=math.cos(yaw_rad) * speed,
+                y=math.sin(yaw_rad) * speed,
+                z=0.0,
+            )
+
+        return ReplayCloneVehicle(transform=clone_tf, velocity=velocity, label="clone")

--- a/opencda/core/common/vehicle_manager.py
+++ b/opencda/core/common/vehicle_manager.py
@@ -11,6 +11,8 @@ import carla
 from opencda.core.actuation.control_manager import ControlManager
 from opencda.core.application.behavior import BehaviorService, TransportMessage, BROADCAST_OWNER_ID, BROADCAST_SERVICE_TYPE, create_service
 from opencda.core.application.platooning.platoon_behavior_agent import PlatooningBehaviorAgent
+from opencda.core.attack import build_attack
+from opencda.core.attack.lidar_jamming import LidarJammingAttack
 from opencda.core.common.v2x_manager import V2XManager
 from opencda.core.sensing.localization.localization_manager import LocalizationManager
 from opencda.core.sensing.perception.perception_manager import PerceptionManager, PerceptionRequirements
@@ -84,7 +86,7 @@ class VehicleManager(object):
         config_yaml: Mapping[str, Any],
         application: Sequence[str],
         carla_map: carla.Map,
-        cav_world: carla.World,
+        cav_world: Any,
         current_time: str = "",
         perception_requirements: PerceptionRequirements | None = None,
         autogenerate_id_on_failure: bool = True,  # TODO: Link with scenario config
@@ -121,8 +123,10 @@ class VehicleManager(object):
                 logger.error("No vehicle ID specified in config.")
                 raise ValueError("No vehicle ID specified in config.")
 
+        self.vid = self.id
         self.vehicle = vehicle
         self.carla_map = carla_map
+        self.cav_world = cav_world
 
         # retrieve the configure for different modules
         sensing_config = config_yaml["sensing"]
@@ -137,11 +141,17 @@ class VehicleManager(object):
         self.carla_autopilot_port = int(config_yaml.get("carla_autopilot_port", behavior_config.get("carla_autopilot_port", 8000)))
         self.perception_requirements = perception_requirements or PerceptionRequirements()
 
-        # v2x module
+        print(f"[V2X CFG] vid={self.vid}, v2x_config={v2x_config}")
+
         self.v2x_manager = V2XManager(cav_world, v2x_config, self.id)
+        # LiDAR jamming is not registered in opencda.core.attack.__init__.py because
+        # its constructor receives VehicleManager directly instead of using from_v2x_config(...).
+        self.lidar_jamming = LidarJammingAttack(self, v2x_config)
         # localization module
         self.localizer = LocalizationManager(vehicle, sensing_config["localization"], carla_map)
         # perception module
+        print(f"[PERCEPTION CFG VEHICLE] vid={self.vid}, perception={sensing_config['perception']}")
+        print(f"[DATA DUMP VEHICLE] vid={self.vid}, data_dumping={self.perception_requirements.enable_data_dump}")
         self.perception_manager = PerceptionManager(
             vehicle=vehicle,
             config_yaml=sensing_config["perception"],
@@ -175,6 +185,13 @@ class VehicleManager(object):
             self.data_dumper: DataDumper | None = DataDumper(self.perception_manager, self.id, save_time=current_time)
         else:
             self.data_dumper = None
+
+        self.attack = build_attack(
+            vid=self.vid,
+            v2x_config=v2x_config,
+            cav_world=cav_world,
+            carla_map=carla_map,
+        )
 
         behavior_services = self.__build_behavior_services(config_yaml)
 
@@ -334,6 +351,11 @@ class VehicleManager(object):
                 out_messages = [msg for msg in result_messages if getattr(msg, "dst_owner_id", None) != self.id]
                 self.behavior_service_results.extend(out_messages)
 
+    def _attack_active(self) -> bool:
+        return bool(getattr(self.attack, "enabled", False)) or bool(
+            getattr(self.lidar_jamming, "enabled", False)
+        )
+
     def set_destination(self, start_location: Location, end_location: Location, clean: bool = False, end_reset: bool = True) -> None:
         """
         Set global route.
@@ -365,6 +387,8 @@ class VehicleManager(object):
         Call perception and localization module to
         retrieve surrounding info an ego position.
         """
+        print(f"[UPDATE_INFO ENTER] vid={self.vid}")
+
         # localization
         self.localizer.localize()
 
@@ -390,7 +414,14 @@ class VehicleManager(object):
 
         # leave this for platooning for now
         self.v2x_manager.update_info(ego_pos, ego_spd)
+        objects = self.lidar_jamming.inject(objects, ego_pos)
+
+        self.attack.tick()
+        objects = self.attack.inject(objects, ego_pos)
+        print(f"[OBJECTS VEHICLES] vid={self.vid}, count={len(objects.get('vehicles', []))}")
+
         self.agent.update_information(ego_pos, ego_spd, objects)
+        print(f"[EGO SPEED] vid={self.vid}, speed={ego_spd}")
         # pass position and speed info to controller
         self.controller.update_info(ego_pos, ego_spd)
 
@@ -405,8 +436,14 @@ class VehicleManager(object):
             target_speed, target_location = self.agent.run_step(target_speed)
         control = self.controller.run_step(target_speed, target_location)
 
+        print(
+            f"[CONTROL] vid={self.vid}, "
+            f"target_speed={target_speed}, throttle={control.throttle:.3f}, "
+            f"brake={control.brake:.3f}, steer={control.steer:.3f}"
+        )
+
         # dump data
-        if self.data_dumper:
+        if self.data_dumper and not self._attack_active():
             self.data_dumper.run_step(self.perception_manager, self.localizer, self.agent)
 
         self.vehicle.apply_control(control)


### PR DESCRIPTION
Restores #141 after the repository history rewrite.

## Summary

- Add Sybil attack, replay attack and lidar spoofing attack

- For every attack added documentation in `docs/md_files/`

- Added little changes in `core/common/vehicle_manager.py` for attacks and logs for debugging

## How to use

Each attack is launched by adding a new field to the vehicle base in the YAML configuration. Next, a standard script is run using opencda ​​(for example, python opencda.py -t rsu_check). A detailed description of all fields used for attacks is described in the MD. Example configuration for 1551_carla_cavs:

``` yaml
  v2x:
    enabled: true
    communication_range: 300
    attack:
      enabled: true
      type: replay
      attacker_vid: cav-5
      record_start: 60  
      buffer_size: 20  
      replay_start: 80   
      lateral_offset: 0
      visible_to_attacker: false
```

## Notes

Sybil attack must be launched without cosim, since in this case the purpose of the attack itself is violated and new caves appear in SUMO

Reply attack must have appropriate parameters. Consider that the attacker is reproducing their own position from the past, so neighbors may not see the attack replica.