### PR TITLE
[CARLA] Add large maps support

### DIFF
--- a/opencda/core/common/world_frame.py
+++ b/opencda/core/common/world_frame.py
@@ -133,6 +133,7 @@ class WorldFrame:
         actor_states: dict[int, WorldActorState],
         traffic_lights: tuple[carla.Actor, ...],
         traffic_light_states: tuple[WorldTrafficLightState, ...],
+        missing_actor_details: dict[int, str],
         cell_size: float,
     ) -> None:
         if cell_size <= 0:
@@ -142,6 +143,7 @@ class WorldFrame:
         self.timestamp = timestamp
         self.traffic_lights = traffic_lights
         self.traffic_light_states = traffic_light_states
+        self._missing_actor_details = missing_actor_details
         self._traffic_light_states_by_id = {state.actor_id: state for state in traffic_light_states}
         self._actor_states = actor_states
         self._cell_size = cell_size
@@ -169,6 +171,7 @@ class WorldFrame:
         actor_states: dict[int, WorldActorState] = {}
         traffic_lights: list[carla.Actor] = []
         traffic_light_states: list[WorldTrafficLightState] = []
+        missing_actor_details: dict[int, str] = {}
 
         for actor in world.get_actors():
             type_id = actor.type_id
@@ -181,6 +184,7 @@ class WorldFrame:
 
             actor_snapshot = snapshot.find(actor.id)
             if actor_snapshot is None:
+                missing_actor_details[actor.id] = cls._describe_missing_actor(actor)
                 continue
 
             actor_states[actor.id] = WorldActorState(
@@ -197,15 +201,30 @@ class WorldFrame:
             actor_states=actor_states,
             traffic_lights=tuple(traffic_lights),
             traffic_light_states=tuple(traffic_light_states),
+            missing_actor_details=missing_actor_details,
             cell_size=cell_size,
         )
+
+    @staticmethod
+    def _describe_missing_actor(actor: carla.Actor) -> str:
+        is_alive = actor.is_alive
+        try:
+            location = actor.get_transform().location
+            location_description = f"({location.x:.2f}, {location.y:.2f}, {location.z:.2f})"
+        except RuntimeError as exc:
+            location_description = f"unavailable ({exc})"
+        return f"type_id={actor.type_id}, is_alive={is_alive}, location={location_description}"
 
     def actor_state(self, actor_id: int) -> WorldActorState:
         """Return a cached actor state or fail on an inconsistent frame."""
         try:
             return self._actor_states[actor_id]
         except KeyError as exc:
-            raise KeyError(f"Actor {actor_id} is absent from CARLA frame {self.frame}.") from exc
+            missing_ids = sorted(self._missing_actor_details)
+            details = self._missing_actor_details.get(actor_id, "actor was not returned by world.get_actors()")
+            raise KeyError(
+                f"Actor {actor_id} is absent from CARLA frame {self.frame}. Missing actor IDs: {missing_ids}. Actor details: {details}."
+            ) from exc
 
     def traffic_light_state(self, actor_id: int) -> WorldTrafficLightState | None:
         """Return the cached state of a traffic light.

--- a/opencda/scenario_testing/config_yaml/default.yaml
+++ b/opencda/scenario_testing/config_yaml/default.yaml
@@ -16,6 +16,12 @@ world:
   # CARLA requires 1 <= max_substeps <= 16. Choose max_substeps as
   # ceil(fixed_delta_seconds / max_substep_delta_time) within that range.
   # Example: 0.2 seconds requires 16 substeps of at least 0.0125 seconds.
+  # Large-map streaming settings, in meters. Actors whose blueprint role_name
+  # contains "hero" or "ego_vehicle" act as streaming sources; this works for
+  # both vehicles and static actors such as RSUs.
+  tile_stream_distance: 3000 # load map tiles within this radius of each streaming source
+  actor_active_distance: 2000 # keep actors active within this radius; must not exceed tile_stream_distance
+  spectator_as_ego: true # use the spectator as the streaming source when no hero actor is present
   seed: 11 # seed for numpy, random, and torch
   weather:
     sun_altitude_angle: 30 # 90 is the midday and -90 is the midnight
@@ -35,6 +41,12 @@ agent_base:
 
 # Define the basic parameters of the rsu
 rsu_base:
+  # CARLA actor role.
+  # "hero" or "ego_vehicle" makes every RSU that inherits this base a large-map streaming source.
+  # Any other role that contains neither substring is non-streaming, for example "rsu".
+  # CARLA uses substring matching, so names such as "not_hero" still enable streaming.
+  # Prefer setting role_name on an individual scenario.rsu_list entry when only one RSU should be a source.
+  role_name: "rsu"
   sensing:
     perception:
       activate: false # when not activated, objects positions will be retrieved from server directly
@@ -69,6 +81,12 @@ rsu_base:
 
 # Basic parameters of the vehicles
 vehicle_base:
+  # Optional CARLA actor role.
+  # "hero" or "ego_vehicle" makes every CAV that inherits this base a large-map streaming source.
+  # Any other role that contains neither substring is non-streaming, for example "cav".
+  # CARLA uses substring matching, so names such as "not_hero" still enable streaming.
+  # Prefer setting role_name on an individual CAV when only selected vehicles should be sources.
+  role_name: "cav"
   sensing: # include perception and localization
     perception:
       activate: false # when not activated, objects positions will be retrieved from server directly

--- a/opencda/scenario_testing/scenario.py
+++ b/opencda/scenario_testing/scenario.py
@@ -210,7 +210,7 @@ class Scenario:
         logger.info(f"created RSU list of size {len(self.rsu_list)}")
         self.runtime_stats["_init_agents"] = time.perf_counter() - t0
 
-    def _init_coperception(self, opt: argparse.Namespace, current_time: str, scenario_params: YamlDict) -> None:
+    def _init_coperception(self, opt: argparse.Namespace, current_time: str, scenario_params: DictConfig) -> None:
         if not os.path.isdir(opt.model_dir):
             self._abort_simulation(f'Model directory "{opt.model_dir}" does not exist; cannot initialize cooperative perception manager.')
 

--- a/opencda/scenario_testing/utils/sim_api.py
+++ b/opencda/scenario_testing/utils/sim_api.py
@@ -250,6 +250,32 @@ class ScenarioManager:
         else:
             sys.exit("ERROR: Current version only supports sync simulation mode")
 
+        spectator_as_ego = simulation_config.get("spectator_as_ego")
+        if spectator_as_ego is not None:
+            if not isinstance(spectator_as_ego, bool):
+                raise ValueError("Config key 'spectator_as_ego' must be a boolean.")
+            new_settings.spectator_as_ego = spectator_as_ego
+
+        streaming_distances: dict[str, float] = {}
+        for key in ("tile_stream_distance", "actor_active_distance"):
+            value = simulation_config.get(key)
+            if value is None:
+                continue
+            if not isinstance(value, (int, float)) or isinstance(value, bool):
+                raise ValueError(f"Config key '{key}' must be a positive number.")
+            distance = float(value)
+            if not math.isfinite(distance) or distance <= 0:
+                raise ValueError(f"Config key '{key}' must be a positive number.")
+            streaming_distances[key] = distance
+
+        tile_stream_distance = streaming_distances.get("tile_stream_distance")
+        actor_active_distance = streaming_distances.get("actor_active_distance")
+        if tile_stream_distance is not None and actor_active_distance is not None and actor_active_distance > tile_stream_distance:
+            raise ValueError("Config key 'actor_active_distance' must be less than or equal to 'tile_stream_distance'.")
+
+        for key, distance in streaming_distances.items():
+            setattr(new_settings, key, distance)
+
         self.world.apply_settings(new_settings)
 
         traffic_config = self.scenario_params.get("carla_traffic_manager")
@@ -515,6 +541,12 @@ class ScenarioManager:
                 actor_blueprint.set_attribute("color", ",".join(map(str, color)))
             except IndexError:
                 logger.warning(f"Actor model {actor_blueprint.id} does not support the 'color' attribute. Skipping.")
+
+        role_name = config.get("role_name")
+        if role_name is not None:
+            if not isinstance(role_name, str) or not role_name:
+                raise ValueError("Config key 'role_name' must be a non-empty string.")
+            actor_blueprint.set_attribute("role_name", role_name)
 
         return actor_blueprint
 

--- a/test/test_sim_api.py
+++ b/test/test_sim_api.py
@@ -442,6 +442,70 @@ def test_substepping_settings_are_applied(mocker):
     assert applied_settings.max_substeps == 16
 
 
+def test_spectator_as_ego_setting_is_applied(mocker):
+    params = _minimal_scenario_params()
+    params["world"]["spectator_as_ego"] = False
+
+    _, world, _ = _make_scenario_manager(mocker, params)
+
+    applied_settings = world.apply_settings.call_args.args[0]
+    assert applied_settings.spectator_as_ego is False
+
+
+def test_invalid_spectator_as_ego_setting_raises(mocker):
+    params = _minimal_scenario_params()
+    params["world"]["spectator_as_ego"] = "false"
+
+    with pytest.raises(ValueError, match="spectator_as_ego.*boolean"):
+        _make_scenario_manager(mocker, params)
+
+
+def test_large_map_streaming_distances_are_applied(mocker):
+    params = _minimal_scenario_params()
+    params["world"].update(
+        {
+            "tile_stream_distance": 25_000,
+            "actor_active_distance": 25_000,
+        }
+    )
+
+    _, world, _ = _make_scenario_manager(mocker, params)
+
+    applied_settings = world.apply_settings.call_args.args[0]
+    assert applied_settings.tile_stream_distance == pytest.approx(25_000)
+    assert applied_settings.actor_active_distance == pytest.approx(25_000)
+
+
+@pytest.mark.parametrize(
+    ("key", "value"),
+    [
+        ("tile_stream_distance", 0),
+        ("tile_stream_distance", float("inf")),
+        ("actor_active_distance", True),
+        ("actor_active_distance", "25000"),
+    ],
+)
+def test_invalid_large_map_streaming_distance_raises(mocker, key, value):
+    params = _minimal_scenario_params()
+    params["world"][key] = value
+
+    with pytest.raises(ValueError, match=rf"{key}.*positive number"):
+        _make_scenario_manager(mocker, params)
+
+
+def test_actor_active_distance_cannot_exceed_tile_stream_distance(mocker):
+    params = _minimal_scenario_params()
+    params["world"].update(
+        {
+            "tile_stream_distance": 2_000,
+            "actor_active_distance": 3_000,
+        }
+    )
+
+    with pytest.raises(ValueError, match="actor_active_distance.*less than or equal"):
+        _make_scenario_manager(mocker, params)
+
+
 def test_invalid_substepping_settings_raise(mocker):
     params = _minimal_scenario_params()
     params["world"].update(
@@ -653,6 +717,30 @@ def test_spawn_custom_actor_color_not_supported(mocker, caplog):
         if r.levelno == logging.WARNING and r.name == sim_api_mod.logger.name and blueprint.id in r.getMessage() and "color" in r.getMessage().lower()
     ]
     assert matching, f"Expected a WARNING from {sim_api_mod.logger.name} mentioning {blueprint.id!r} and color; got:\n{caplog.text}"
+
+
+def test_spawn_custom_actor_sets_role_name(mocker):
+    sm, world, bp_lib, blueprint = _setup_spawn_custom_actor(mocker)
+
+    spawn_transform = Mock(spec_set=[])
+    config = {"model": "vehicle.tesla.model3", "role_name": "hero"}
+
+    result = sm.spawn_custom_actor(spawn_transform, config, fallback_model="vehicle.lincoln.mkz_2017")
+
+    assert result == "ACTOR"
+    bp_lib.find.assert_called_once_with("vehicle.tesla.model3")
+    blueprint.set_attribute.assert_called_once_with("role_name", "hero")
+    world.spawn_actor.assert_called_once_with(blueprint, spawn_transform)
+
+
+def test_spawn_custom_actor_rejects_empty_role_name(mocker):
+    sm, world, _, blueprint = _setup_spawn_custom_actor(mocker)
+
+    with pytest.raises(ValueError, match="role_name.*non-empty string"):
+        sm.spawn_custom_actor(Mock(spec_set=[]), {"role_name": ""}, fallback_model="vehicle.lincoln.mkz_2017")
+
+    blueprint.set_attribute.assert_not_called()
+    world.spawn_actor.assert_not_called()
 
 
 def test_close_restores_settings(mocker):

--- a/test/test_world_frame.py
+++ b/test/test_world_frame.py
@@ -55,6 +55,25 @@ def test_capture_reads_world_once_and_uses_actor_snapshots() -> None:
     vehicle.get_velocity.assert_not_called()
 
 
+def test_missing_actor_error_includes_lifecycle_diagnostics() -> None:
+    missing_actor = _actor(7, "vehicle.missing")
+    missing_actor.is_alive = False
+    missing_actor.get_transform.return_value = carla.Transform(carla.Location(x=1.25, y=-2.5, z=-101.0))
+    world_snapshot = Mock(frame=23, timestamp=SimpleNamespace(elapsed_seconds=5.0))
+    world_snapshot.find.return_value = None
+    world = Mock()
+    world.get_snapshot.return_value = world_snapshot
+    world.get_actors.return_value = [missing_actor]
+
+    world_frame = WorldFrame.capture(world)
+
+    with pytest.raises(
+        KeyError,
+        match=r"Actor 7.*Missing actor IDs: \[7\].*is_alive=False.*location=\(1.25, -2.50, -101.00\)",
+    ):
+        world_frame.actor_state(7)
+
+
 def test_spatial_queries_filter_radius_type_and_actor_id() -> None:
     actors = {
         1: _actor(1, "vehicle.ego"),


### PR DESCRIPTION
## Summary
Adds configurable CARLA large-map streaming support to OpenCDA. Scenarios can now control tile streaming and actor activation distances, use CAVs or RSUs as streaming sources, and receive better diagnostics when actors disappear from a CARLA frame.

## Changes
- Added support for `tile_stream_distance`, `actor_active_distance`, and `spectator_as_ego` world settings, including validation and documented defaults.
- Added configurable actor `role_name` propagation for CAV and RSU blueprints, enabling static RSUs to act as large-map streaming sources.
- Improved missing-actor diagnostics with actor IDs, lifecycle state, type, and last available location.
- Fixed the CoP initialization type annotation to accept `DictConfig`.
- Added unit coverage for streaming settings, role validation, and missing-actor diagnostics.

## Validation
- [x] Simulation run
- [x] Manual verification

## Checklist
- [x] Kept the PR focused and reviewable
- [x] Updated documentation
- [x] Added or updated validation steps